### PR TITLE
Implement initial sdev toolkit (Python + CLI)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ htmlcov/
 dist/
 build/
 *.log
+.config/

--- a/development.md
+++ b/development.md
@@ -10,8 +10,8 @@ This experiment runs **two Claude Code CLI agents in adversarial collaboration**
    Before writing or changing code, review **open GitHub Issues** created by the test workflow for this repository. Use the GitHub CLI, e.g. `gh issue list --state open` (and the filters or labels described in `test.md`). **Do not** rely on a local markdown handoff file for test feedback. Triage each relevant issue: fix, comment with evidence, or close with `gh issue close <number>` when resolved. Do not ignore open issues from the test agent.
 
 2. **Respect the serial-port time window (shared device)**  
-   Split each clock hour in half: **dev** may use the serial from **`:00` through `:29`**; **test** from **`:30` through `:59`**.  
-   **Do not** use `/dev/ttyUSB0` (or the configured device) during **`:30`–`:59`**. If a serial run might cross **`:29` → `:30`**, stop or finish before **`:30`**.
+   Use **minute-of-hour modulo 10**: let `m` be the current minute within the hour (`0–59`). **Dev** may use the serial only when **`m % 10` is 0–4** (e.g. `…:00`–`…:04`, `…:10`–`…:14`, `…:50`–`…:54`). **Test** uses **`m % 10` 5–9** (e.g. `…:05`–`…:09`, `…:15`–`…:19`, `…:55`–`…:59`). Same **5-minute dev / 5-minute test** pattern repeats every ten minutes all hour.  
+   **Do not** open or use `/dev/ttyUSB0` (or the configured device) when `m % 10` is **5–9**. If a serial operation would cross from **`m % 10 ≤ 4`** into **`m % 10 ≥ 5`**, **stop or yield before** that boundary (e.g. finish by `…:04` if you are in a dev slice ending at `…:04`).
 
 3. **Sync `main` before you implement**  
    At the start of a dev stint (and before cutting a **new** feature branch), run:  
@@ -75,7 +75,6 @@ Real usage is not only **executing** shell commands over serial but also **recei
 > A GitHub issue was opened by the human operator to record this scope: see [GitHub issue #2](https://github.com/klrc/sdev-autoresearch/issues/2). Agents must **not** treat this expansion as erroneous feedback from the test agent or revert it as a "mistake".
 
 ---
-
 
 ## Files you must not edit
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,13 @@
+[build-system]
+requires = ["setuptools>=64"]
+build-backend = "setuptools.backends._legacy:_Backend"
+
+[project]
+name = "sdev"
+version = "0.1.0"
+description = "Small toolkit for automating a serial-attached Linux shell"
+requires-python = ">=3.10"
+dependencies = ["pyserial"]
+
+[project.scripts]
+sdev = "sdev.__main__:main"

--- a/sdev/__init__.py
+++ b/sdev/__init__.py
@@ -3,9 +3,13 @@
 Python API::
 
     import sdev
-    sdev.connect("/dev/ttyUSB0", 115200)
-    result = sdev.cli("ls /proc/meminfo")
+    session = sdev.SerialSession("/dev/ttyUSB0", 115200)
+    result = session.cli("ls /proc/meminfo")
     print(result.output)
+
+    # Streaming mode for long output::
+    for chunk in session.stream("tail -f /var/log/syslog"):
+        process(chunk)
 
 CLI::
 
@@ -16,10 +20,12 @@ CLI::
 
 import os
 import time
+import re
 import serial
 from pathlib import Path
-from dataclasses import dataclass
-from typing import Optional
+from dataclasses import dataclass, field
+from typing import Optional, Iterator, Callable
+
 
 # ---------------------------------------------------------------------------
 # Configuration
@@ -32,6 +38,10 @@ CONFIG_DIR = Path.home() / ".config" / "sdev"
 CONFIG_FILE = CONFIG_DIR / "defaults.json"
 
 
+# ---------------------------------------------------------------------------
+# Data types
+# ---------------------------------------------------------------------------
+
 @dataclass
 class SerialResult:
     """Output from a single command execution."""
@@ -42,55 +52,19 @@ class SerialResult:
     elapsed: float
 
 
-# ---------------------------------------------------------------------------
-# Global state
-# ---------------------------------------------------------------------------
+@dataclass
+class ParseResult:
+    """Structured result after parsing command output."""
 
-_connection: Optional[serial.Serial] = None
-_baud: int = DEFAULT_BAUD
-_device: str = DEFAULT_DEVICE
-
-
-def connect(device: Optional[str] = None, baud: int = DEFAULT_BAUD) -> None:
-    """Open (or reopen) the serial connection.
-
-    If a connection is already open it is closed first so callers can
-    reconnect to a device that may have reset.
-    """
-    global _connection, _baud, _device
-
-    _device = device or _device
-    _baud = baud
-
-    if _connection is not None:
-        try:
-            _connection.close()
-        except Exception:
-            pass
-        _connection = None
-
-    _connection = serial.Serial(_device, _baud, timeout=0.1)
-    # Drain any leftover noise from the buffer
-    time.sleep(0.5)
-    _connection.reset_input_buffer()
-    _connection.reset_output_buffer()
-
-
-def ensure_connection() -> serial.Serial:
-    """Return the open connection or raise if not connected."""
-    if _connection is None or not _connection.is_open:
-        raise RuntimeError(
-            f"Not connected. Call sdev.connect('{_device}', {_baud}) first."
-        )
-    return _connection
+    lines: list[str] = field(default_factory=list)
+    matched: list[str] = field(default_factory=list)
+    raw: str = ""
 
 
 # ---------------------------------------------------------------------------
 # Prompt detection
 # ---------------------------------------------------------------------------
 
-# Common shell prompts — we consider output "done" when we see one of these
-# at the end of the buffer.  Callers can also rely on a timeout.
 PROMPTS = [b"# ", b"$ ", b"> ", b"~# ", b"~$ "]
 
 
@@ -104,52 +78,211 @@ def _prompt_detected(buf: bytes) -> bool:
 
 
 # ---------------------------------------------------------------------------
-# Core command execution
+# SerialSession — explicit connection object (issue #3)
 # ---------------------------------------------------------------------------
 
-def cli(command: str, timeout: Optional[float] = None) -> SerialResult:
-    """Send *command* over serial and return its output.
+class SerialSession:
+    """Manages a single serial connection with command execution and streaming."""
 
-    Waits until a shell prompt reappears or *timeout* seconds elapse
-    (default: :data:`DEFAULT_TIMEOUT` — 5 minutes).
+    def __init__(self, device: str = DEFAULT_DEVICE, baud: int = DEFAULT_BAUD):
+        self._connection: Optional[serial.Serial] = None
+        self.device = device
+        self.baud = baud
 
-    Returns a :class:`SerialResult` with ``output``, ``timed_out``, and
-    ``elapsed``.
-    """
-    ser = ensure_connection()
-    deadline = (timeout or DEFAULT_TIMEOUT)
-    start = time.monotonic()
+    @property
+    def is_open(self) -> bool:
+        return self._connection is not None and self._connection.is_open
 
-    ser.reset_input_buffer()
-    ser.write((command + "\n").encode())
-    ser.flush()
+    def connect(self, device: Optional[str] = None, baud: Optional[int] = None) -> None:
+        """Open (or reopen) the serial connection."""
+        if device is not None:
+            self.device = device
+        if baud is not None:
+            self.baud = baud
 
-    buf = bytearray()
-    timed_out = False
+        if self._connection is not None:
+            try:
+                self._connection.close()
+            except Exception:
+                pass
+            self._connection = None
 
-    while True:
-        remaining = deadline - (time.monotonic() - start)
-        if remaining <= 0:
-            timed_out = True
-            break
+        self._connection = serial.Serial(self.device, self.baud, timeout=0.1)
+        time.sleep(0.5)
+        self._connection.reset_input_buffer()
+        self._connection.reset_output_buffer()
 
-        # Read whatever is available (non-blocking, timeout=0.1 on the port)
-        chunk = ser.read(4096)
-        if chunk:
-            buf.extend(chunk)
-            if _prompt_detected(bytes(buf)):
+    def _ensure_open(self) -> serial.Serial:
+        if not self.is_open:
+            raise RuntimeError(
+                f"Not connected. Call connect('{self.device}', {self.baud}) first."
+            )
+        return self._connection  # type: ignore
+
+    def close(self) -> None:
+        """Close the serial connection if open."""
+        if self._connection is not None:
+            try:
+                self._connection.close()
+            except Exception:
+                pass
+            self._connection = None
+
+    def cli(self, command: str, timeout: Optional[float] = None) -> SerialResult:
+        """Send *command* over serial and return its output.
+
+        Waits until a shell prompt reappears or *timeout* seconds elapse.
+        """
+        ser = self._ensure_open()
+        deadline = timeout or DEFAULT_TIMEOUT
+        start = time.monotonic()
+
+        ser.reset_input_buffer()
+        ser.write((command + "\n").encode())
+        ser.flush()
+
+        buf = bytearray()
+        timed_out = False
+
+        while True:
+            remaining = deadline - (time.monotonic() - start)
+            if remaining <= 0:
+                timed_out = True
                 break
-        else:
-            # Nothing to read — sleep briefly to avoid a tight loop
-            time.sleep(min(0.1, remaining))
 
-    elapsed = time.monotonic() - start
-    return SerialResult(
-        command=command,
-        output=bytes(buf).decode(errors="replace"),
-        timed_out=timed_out,
-        elapsed=round(elapsed, 2),
-    )
+            chunk = ser.read(4096)
+            if chunk:
+                buf.extend(chunk)
+                if _prompt_detected(bytes(buf)):
+                    break
+            else:
+                time.sleep(min(0.1, remaining))
+
+        elapsed = time.monotonic() - start
+        return SerialResult(
+            command=command,
+            output=bytes(buf).decode(errors="replace"),
+            timed_out=timed_out,
+            elapsed=round(elapsed, 2),
+        )
+
+    def stream(
+        self,
+        command: str,
+        timeout: Optional[float] = None,
+        chunk_size: int = 256,
+        filter_fn: Optional[Callable[[str], str]] = None,
+    ) -> Iterator[str]:
+        """Yield output incrementally as it arrives.
+
+        Suitable for long-running commands or large output where buffering
+        the entire transcript in memory is impractical.
+
+        Yields decoded string chunks.  Stops when *timeout* elapses.
+
+        *filter_fn*: optional callable applied to each chunk before yielding.
+        """
+        ser = self._ensure_open()
+        deadline = timeout or DEFAULT_TIMEOUT
+        start = time.monotonic()
+
+        ser.reset_input_buffer()
+        ser.write((command + "\n").encode())
+        ser.flush()
+
+        while True:
+            remaining = deadline - (time.monotonic() - start)
+            if remaining <= 0:
+                break
+
+            chunk = ser.read(chunk_size)
+            if chunk:
+                text = chunk.decode(errors="replace")
+                if filter_fn:
+                    text = filter_fn(text)
+                yield text
+                if _prompt_detected(chunk):
+                    break
+            else:
+                time.sleep(min(0.1, remaining))
+
+    def parse(
+        self,
+        command: str,
+        pattern: Optional[str] = None,
+        timeout: Optional[float] = None,
+    ) -> ParseResult:
+        """Run *command*, then return parsed/structured output.
+
+        If *pattern* is given (regex), only matching lines are kept in
+        ``matched``.
+        """
+        result = self.cli(command, timeout)
+        lines = [l for l in result.output.splitlines() if l.strip()]
+        matched: list[str] = []
+        if pattern:
+            regex = re.compile(pattern)
+            matched = [l for l in lines if regex.search(l)]
+        return ParseResult(lines=lines, matched=matched, raw=result.output)
+
+    def __enter__(self):
+        if not self.is_open:
+            self.connect()
+        return self
+
+    def __exit__(self, *args):
+        self.close()
+
+
+# ---------------------------------------------------------------------------
+# Module-level convenience APIs (backward compatibility)
+# ---------------------------------------------------------------------------
+
+_default_session = SerialSession()
+
+
+def connect(device: Optional[str] = None, baud: int = DEFAULT_BAUD) -> None:
+    """Open (or reopen) the default serial connection."""
+    _default_session.connect(device, baud)
+
+
+def ensure_connection() -> serial.Serial:
+    """Return the open default connection or raise if not connected."""
+    return _default_session._ensure_open()
+
+
+def cli(command: str, timeout: Optional[float] = None) -> SerialResult:
+    """Send *command* over the default connection and return output."""
+    return _default_session.cli(command, timeout)
+
+
+def run(device: str, baud: int, command: str, timeout: Optional[float] = None) -> SerialResult:
+    """Open connection, run *command*, close. One-shot helper."""
+    session = SerialSession(device, baud)
+    session.connect()
+    try:
+        return session.cli(command, timeout)
+    finally:
+        session.close()
+
+
+def stream(
+    command: str,
+    timeout: Optional[float] = None,
+    chunk_size: int = 256,
+    filter_fn: Optional[Callable[[str], str]] = None,
+) -> Iterator[str]:
+    """Yield output from the default connection incrementally."""
+    yield from _default_session.stream(command, timeout, chunk_size, filter_fn)
+
+
+def parse(
+    command: str,
+    pattern: Optional[str] = None,
+    timeout: Optional[float] = None,
+) -> ParseResult:
+    """Run *command* on the default connection and return parsed output."""
+    return _default_session.parse(command, pattern, timeout)
 
 
 # ---------------------------------------------------------------------------
@@ -171,17 +304,3 @@ def load_defaults() -> dict:
     if CONFIG_FILE.exists():
         return json.loads(CONFIG_FILE.read_text())
     return {}
-
-
-# ---------------------------------------------------------------------------
-# Convenience: connect + one-shot command
-# ---------------------------------------------------------------------------
-
-def run(device: str, baud: int, command: str, timeout: Optional[float] = None) -> SerialResult:
-    """Open connection, run *command*, close connection. One-shot helper."""
-    connect(device, baud)
-    try:
-        return cli(command, timeout)
-    finally:
-        if _connection is not None:
-            _connection.close()

--- a/sdev/__init__.py
+++ b/sdev/__init__.py
@@ -1,0 +1,187 @@
+"""sdev — small toolkit for automating a serial-attached Linux shell.
+
+Python API::
+
+    import sdev
+    sdev.connect("/dev/ttyUSB0", 115200)
+    result = sdev.cli("ls /proc/meminfo")
+    print(result.output)
+
+CLI::
+
+    sdev -p "ls /proc/meminfo" -d /dev/ttyUSB0 -b 115200
+    sdev set-default /dev/ttyUSB0 115200
+    sdev -p "ls /proc/meminfo"          # uses saved defaults
+"""
+
+import os
+import time
+import serial
+from pathlib import Path
+from dataclasses import dataclass
+from typing import Optional
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+DEFAULT_TIMEOUT = 300  # 5 minutes — strict cap on blocking operations
+DEFAULT_BAUD = 115200
+DEFAULT_DEVICE = "/dev/ttyUSB0"
+CONFIG_DIR = Path.home() / ".config" / "sdev"
+CONFIG_FILE = CONFIG_DIR / "defaults.json"
+
+
+@dataclass
+class SerialResult:
+    """Output from a single command execution."""
+
+    command: str
+    output: str
+    timed_out: bool
+    elapsed: float
+
+
+# ---------------------------------------------------------------------------
+# Global state
+# ---------------------------------------------------------------------------
+
+_connection: Optional[serial.Serial] = None
+_baud: int = DEFAULT_BAUD
+_device: str = DEFAULT_DEVICE
+
+
+def connect(device: Optional[str] = None, baud: int = DEFAULT_BAUD) -> None:
+    """Open (or reopen) the serial connection.
+
+    If a connection is already open it is closed first so callers can
+    reconnect to a device that may have reset.
+    """
+    global _connection, _baud, _device
+
+    _device = device or _device
+    _baud = baud
+
+    if _connection is not None:
+        try:
+            _connection.close()
+        except Exception:
+            pass
+        _connection = None
+
+    _connection = serial.Serial(_device, _baud, timeout=0.1)
+    # Drain any leftover noise from the buffer
+    time.sleep(0.5)
+    _connection.reset_input_buffer()
+    _connection.reset_output_buffer()
+
+
+def ensure_connection() -> serial.Serial:
+    """Return the open connection or raise if not connected."""
+    if _connection is None or not _connection.is_open:
+        raise RuntimeError(
+            f"Not connected. Call sdev.connect('{_device}', {_baud}) first."
+        )
+    return _connection
+
+
+# ---------------------------------------------------------------------------
+# Prompt detection
+# ---------------------------------------------------------------------------
+
+# Common shell prompts — we consider output "done" when we see one of these
+# at the end of the buffer.  Callers can also rely on a timeout.
+PROMPTS = [b"# ", b"$ ", b"> ", b"~# ", b"~$ "]
+
+
+def _prompt_detected(buf: bytes) -> bool:
+    """Return True if a known shell prompt appears at the tail of *buf*."""
+    stripped = buf.rstrip(b"\r\n")
+    for p in PROMPTS:
+        if stripped.endswith(p):
+            return True
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Core command execution
+# ---------------------------------------------------------------------------
+
+def cli(command: str, timeout: Optional[float] = None) -> SerialResult:
+    """Send *command* over serial and return its output.
+
+    Waits until a shell prompt reappears or *timeout* seconds elapse
+    (default: :data:`DEFAULT_TIMEOUT` — 5 minutes).
+
+    Returns a :class:`SerialResult` with ``output``, ``timed_out``, and
+    ``elapsed``.
+    """
+    ser = ensure_connection()
+    deadline = (timeout or DEFAULT_TIMEOUT)
+    start = time.monotonic()
+
+    ser.reset_input_buffer()
+    ser.write((command + "\n").encode())
+    ser.flush()
+
+    buf = bytearray()
+    timed_out = False
+
+    while True:
+        remaining = deadline - (time.monotonic() - start)
+        if remaining <= 0:
+            timed_out = True
+            break
+
+        # Read whatever is available (non-blocking, timeout=0.1 on the port)
+        chunk = ser.read(4096)
+        if chunk:
+            buf.extend(chunk)
+            if _prompt_detected(bytes(buf)):
+                break
+        else:
+            # Nothing to read — sleep briefly to avoid a tight loop
+            time.sleep(min(0.1, remaining))
+
+    elapsed = time.monotonic() - start
+    return SerialResult(
+        command=command,
+        output=bytes(buf).decode(errors="replace"),
+        timed_out=timed_out,
+        elapsed=round(elapsed, 2),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Persistent defaults
+# ---------------------------------------------------------------------------
+
+def save_default(device: str, baud: int) -> None:
+    """Persist default device/baud so subsequent CLI invocations can omit them."""
+    import json
+
+    CONFIG_DIR.mkdir(parents=True, exist_ok=True)
+    CONFIG_FILE.write_text(json.dumps({"device": device, "baud": baud}))
+
+
+def load_defaults() -> dict:
+    """Return saved defaults (or empty dict if none exist)."""
+    import json
+
+    if CONFIG_FILE.exists():
+        return json.loads(CONFIG_FILE.read_text())
+    return {}
+
+
+# ---------------------------------------------------------------------------
+# Convenience: connect + one-shot command
+# ---------------------------------------------------------------------------
+
+def run(device: str, baud: int, command: str, timeout: Optional[float] = None) -> SerialResult:
+    """Open connection, run *command*, close connection. One-shot helper."""
+    connect(device, baud)
+    try:
+        return cli(command, timeout)
+    finally:
+        if _connection is not None:
+            _connection.close()

--- a/sdev/__main__.py
+++ b/sdev/__main__.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""CLI entry point for sdev.
+
+Usage::
+
+    sdev -p "ls /proc/meminfo" -d /dev/ttyUSB0 -b 115200
+    sdev set-default /dev/ttyUSB0 115200
+    sdev -p "ls /proc/meminfo"          # uses saved defaults
+"""
+
+import argparse
+import sys
+
+import sdev
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        prog="sdev",
+        description="Run a command on a serial-attached Linux shell.",
+    )
+    parser.add_argument(
+        "-p", "--command",
+        help="Command to execute on the remote shell.",
+    )
+    parser.add_argument(
+        "-d", "--device",
+        help="Serial device path (default: saved default or /dev/ttyUSB0).",
+    )
+    parser.add_argument(
+        "-b", "--baud",
+        type=int,
+        help="Baud rate (default: saved default or 115200).",
+    )
+
+    sub = parser.add_subparsers(dest="subcommand")
+    sub.add_parser(
+        "set-default",
+        help="Persist device/baud as the default for future invocations.",
+    )
+
+    args = parser.parse_args()
+
+    # --- set-default subcommand ---
+    if args.subcommand == "set-default":
+        if args.device is None or args.baud is None:
+            parser.error("set-default requires -d DEVICE and -b BAUD")
+        sdev.save_default(args.device, args.baud)
+        print(f"Default saved: {args.device} @ {args.baud}")
+        return
+
+    # --- normal -p execution ---
+    if args.command is None:
+        parser.print_help()
+        sys.exit(1)
+
+    # Load saved defaults, then override with CLI flags
+    defaults = sdev.load_defaults()
+    device = args.device or defaults.get("device", sdev.DEFAULT_DEVICE)
+    baud = args.baud or defaults.get("baud", sdev.DEFAULT_BAUD)
+
+    result = sdev.run(device, baud, args.command)
+
+    if result.output:
+        sys.stdout.write(result.output)
+    if result.timed_out:
+        print(
+            f"\n[sdev] command timed out after {result.elapsed:.1f}s",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+
+
+if __name__ == "__main__":
+    main()

--- a/test.md
+++ b/test.md
@@ -2,7 +2,7 @@
 
 This document defines the **test** agent’s responsibilities in the **adversarial pair** with the dev agent (`development.md`). The test agent should run in a **separate git worktree** from dev to avoid concurrent edits to the same tree.
 
-**Serial time-sharing (same rule as `development.md`):** **test** uses the serial **`:30`–`:59`** each hour; **dev** uses **`:00`–`:29`**. Details below.
+**Serial time-sharing (same rule as `development.md`):** let `m` be the minute-of-hour (`0–59`). **Test** may use the serial **only** when **`m % 10` is 5–9**; **dev** owns **`m % 10` 0–4**. Do not touch the serial outside your slice — full wording in [Serial-port time window](#serial-port-time-window-mandatory) below.
 
 ---
 
@@ -12,13 +12,15 @@ This document defines the **test** agent’s responsibilities in the **adversari
 
 The serial device (default `/dev/ttyUSB0`) is **single-user** across both agents.
 
-| Agent | Serial window (each clock hour, local time) |
-|--------|-----------------------------------------------|
-| **Dev** | **`:00`–`:29`** |
-| **Test** | **`:30`–`:59`** |
+Let `m` be the current **minute-of-hour** (`0–59`). **Dev** may use the serial when **`m % 10` is 0–4**; **test** when **`m % 10` is 5–9**. That is a repeating **5-minute dev / 5-minute test** cadence every ten minutes (e.g. `…:00`–`…:04` dev, `…:05`–`…:09` test, `…:10`–`…:14` dev, `…:15`–`…:19` test, …).
 
-- **Before** any serial I/O, confirm the minute is **`:30`–`:59`**. Otherwise **wait**; do not contend with dev.
-- **Assume** dev may use the device **`:00`–`:29`**.
+| Agent | Condition (same every hour) |
+|--------|-----------------------------|
+| **Dev** | **`m % 10` ∈ {0,1,2,3,4}** |
+| **Test** | **`m % 10` ∈ {5,6,7,8,9}** |
+
+- **Before** any serial I/O, confirm **`m % 10` is 5–9**. If not, **wait** or reschedule; do not contend with dev.
+- **Assume** dev may use the device when **`m % 10` is 0–4**; do not start serial-heavy runs in those slices.
 
 ### GitHub issue handoff
 

--- a/tests/test_sdev.py
+++ b/tests/test_sdev.py
@@ -1,9 +1,8 @@
-"""Basic tests for sdev — no real hardware required."""
+"""Tests for sdev — no real hardware required."""
 
-import json
 import unittest
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, patch, mock_open
 
 import sdev
 
@@ -15,6 +14,14 @@ class TestSerialResult(unittest.TestCase):
         self.assertEqual(r.output, "hi\n")
         self.assertFalse(r.timed_out)
         self.assertAlmostEqual(r.elapsed, 0.5)
+
+
+class TestParseResult(unittest.TestCase):
+    def test_empty(self):
+        r = sdev.ParseResult()
+        self.assertEqual(r.lines, [])
+        self.assertEqual(r.matched, [])
+        self.assertEqual(r.raw, "")
 
 
 class TestConfig(unittest.TestCase):
@@ -50,23 +57,127 @@ class TestPromptDetection(unittest.TestCase):
         self.assertFalse(sdev._prompt_detected(b"some random output"))
 
 
-class TestEnsureConnection(unittest.TestCase):
-    def test_raises_when_not_connected(self):
-        with patch.object(sdev, "_connection", None):
-            with self.assertRaises(RuntimeError):
-                sdev.ensure_connection()
+class TestSerialSession(unittest.TestCase):
+    def test_init_defaults(self):
+        sess = sdev.SerialSession()
+        self.assertEqual(sess.device, sdev.DEFAULT_DEVICE)
+        self.assertEqual(sess.baud, sdev.DEFAULT_BAUD)
 
+    def test_connect_opens_port(self):
+        with patch("sdev.serial.Serial") as mock_cls:
+            sess = sdev.SerialSession("/dev/ttyS0", 9600)
+            sess.connect()
+            mock_cls.assert_called_once_with("/dev/ttyS0", 9600, timeout=0.1)
+            self.assertTrue(sess.is_open)
 
-class TestCliWithTimeout(unittest.TestCase):
-    def test_timeout_returns_early(self):
+    def test_close(self):
+        with patch("sdev.serial.Serial") as mock_cls:
+            mock_ser = mock_cls.return_value
+            sess = sdev.SerialSession()
+            sess.connect()
+            sess.close()
+            mock_ser.close.assert_called_once()
+            self.assertFalse(sess.is_open)
+
+    def test_ensure_open_raises(self):
+        sess = sdev.SerialSession()
+        with self.assertRaises(RuntimeError):
+            sess._ensure_open()
+
+    def test_context_manager(self):
+        with patch("sdev.serial.Serial") as mock_cls:
+            mock_ser = mock_cls.return_value
+            with sdev.SerialSession() as sess:
+                self.assertTrue(sess.is_open)
+            mock_ser.close.assert_called_once()
+
+    def test_cli_timeout(self):
         mock_ser = MagicMock()
         mock_ser.is_open = True
         mock_ser.read.return_value = b""
 
-        with patch.object(sdev, "_connection", mock_ser):
-            result = sdev.cli("sleep 999", timeout=0.2)
-            self.assertTrue(result.timed_out)
-            self.assertGreater(result.elapsed, 0.15)
+        sess = sdev.SerialSession()
+        sess._connection = mock_ser
+
+        result = sess.cli("sleep 999", timeout=0.2)
+        self.assertTrue(result.timed_out)
+        self.assertGreater(result.elapsed, 0.15)
+
+    def test_stream_yields_chunks(self):
+        mock_ser = MagicMock()
+        mock_ser.is_open = True
+        mock_ser.read.side_effect = [b"hello ", b"world\n# ", b""]
+
+        sess = sdev.SerialSession()
+        sess._connection = mock_ser
+
+        chunks = list(sess.stream("echo hello world"))
+        self.assertEqual(chunks, ["hello ", "world\n# "])
+
+    def test_stream_timeout(self):
+        mock_ser = MagicMock()
+        mock_ser.is_open = True
+        mock_ser.read.return_value = b""
+
+        sess = sdev.SerialSession()
+        sess._connection = mock_ser
+
+        chunks = list(sess.stream("long-running", timeout=0.2))
+        self.assertEqual(chunks, [])
+
+    def test_parse_no_pattern(self):
+        mock_ser = MagicMock()
+        mock_ser.is_open = True
+        mock_ser.read.side_effect = [b"line1\nline2\n\n# ", b""]
+
+        sess = sdev.SerialSession()
+        sess._connection = mock_ser
+
+        r = sess.parse("cat file")
+        self.assertEqual(r.lines, ["line1", "line2", "# "])
+        self.assertEqual(r.matched, [])
+
+    def test_parse_with_pattern(self):
+        mock_ser = MagicMock()
+        mock_ser.is_open = True
+        mock_ser.read.side_effect = [b"error: bad\nok: fine\n# ", b""]
+
+        sess = sdev.SerialSession()
+        sess._connection = mock_ser
+
+        r = sess.parse("cat file", pattern=r"^error")
+        self.assertEqual(r.matched, ["error: bad"])
+
+
+class TestModuleLevelAPI(unittest.TestCase):
+    """Backward-compat wrappers delegate to _default_session."""
+
+    def test_ensure_raises_when_not_connected(self):
+        sdev._default_session._connection = None
+        with self.assertRaises(RuntimeError):
+            sdev.ensure_connection()
+
+    def test_cli_delegates_timeout(self):
+        mock_ser = MagicMock()
+        mock_ser.is_open = True
+        mock_ser.read.return_value = b""
+
+        sdev._default_session._connection = mock_ser
+        result = sdev.cli("sleep 999", timeout=0.2)
+        self.assertTrue(result.timed_out)
+
+
+class TestRunOneShot(unittest.TestCase):
+    def test_run_opens_and_closes(self):
+        with patch("sdev.serial.Serial") as mock_cls:
+            mock_ser = mock_cls.return_value
+            mock_ser.is_open = True
+            mock_ser.read.side_effect = [b"done\n# ", b""]
+
+            result = sdev.run("/dev/ttyS0", 9600, "echo done")
+            mock_cls.assert_called_once_with("/dev/ttyS0", 9600, timeout=0.1)
+            mock_ser.close.assert_called_once()
+            self.assertFalse(result.timed_out)
 
 
 if __name__ == "__main__":

--- a/tests/test_sdev.py
+++ b/tests/test_sdev.py
@@ -1,0 +1,73 @@
+"""Basic tests for sdev — no real hardware required."""
+
+import json
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import sdev
+
+
+class TestSerialResult(unittest.TestCase):
+    def test_dataclass_fields(self):
+        r = sdev.SerialResult("echo hi", "hi\n", False, 0.5)
+        self.assertEqual(r.command, "echo hi")
+        self.assertEqual(r.output, "hi\n")
+        self.assertFalse(r.timed_out)
+        self.assertAlmostEqual(r.elapsed, 0.5)
+
+
+class TestConfig(unittest.TestCase):
+    def setUp(self):
+        self._orig = sdev.CONFIG_FILE
+
+    def tearDown(self):
+        sdev.CONFIG_FILE = self._orig
+
+    def test_save_and_load_defaults(self):
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as td:
+            sdev.CONFIG_FILE = Path(td) / "defaults.json"
+            sdev.save_default("/dev/ttyUSB1", 9600)
+            d = sdev.load_defaults()
+            self.assertEqual(d, {"device": "/dev/ttyUSB1", "baud": 9600})
+
+    def test_load_defaults_missing(self):
+        with patch.object(sdev, "CONFIG_FILE", Path("/nonexistent/path")):
+            self.assertEqual(sdev.load_defaults(), {})
+
+
+class TestPromptDetection(unittest.TestCase):
+    def test_hash_prompt(self):
+        self.assertTrue(sdev._prompt_detected(b"root@box:~# "))
+        self.assertTrue(sdev._prompt_detected(b"output\n# "))
+
+    def test_dollar_prompt(self):
+        self.assertTrue(sdev._prompt_detected(b"user@host $ "))
+
+    def test_no_prompt(self):
+        self.assertFalse(sdev._prompt_detected(b"some random output"))
+
+
+class TestEnsureConnection(unittest.TestCase):
+    def test_raises_when_not_connected(self):
+        with patch.object(sdev, "_connection", None):
+            with self.assertRaises(RuntimeError):
+                sdev.ensure_connection()
+
+
+class TestCliWithTimeout(unittest.TestCase):
+    def test_timeout_returns_early(self):
+        mock_ser = MagicMock()
+        mock_ser.is_open = True
+        mock_ser.read.return_value = b""
+
+        with patch.object(sdev, "_connection", mock_ser):
+            result = sdev.cli("sleep 999", timeout=0.2)
+            self.assertTrue(result.timed_out)
+            self.assertGreater(result.elapsed, 0.15)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add `sdev` package with Python API: `sdev.connect()`, `sdev.cli()`, `sdev.run()`, `sdev.stream()`, `sdev.parse()`
- Add `SerialSession` class with explicit connection state (replaces module-level globals per issue #3)
- Add CLI entry point: `sdev -p "cmd" -d /dev/ttyUSB0 -b 115200`, `sdev set-default`
- Strict 5-minute timeout on all blocking serial operations per `development.md`
- Prompt detection (`# `, `$ `, `> `) to determine command completion
- Persisted defaults via `~/.config/sdev/defaults.json`
- 20 unit tests (mocked serial, no hardware required)

## Changes since last push
- **Rebased onto latest main** to resolve merge conflicts in `development.md` and `test.md`
- **Refactored globals into `SerialSession` class** (issue #3 feedback): `_connection`, `_baud`, `_device` are now instance attributes with explicit lifecycle, context manager support, and backward-compatible module-level wrappers
- **Added streaming** (`SerialSession.stream()`, module-level `sdev.stream()`) — incremental yield of output chunks for long-running commands (issue #2)
- **Added parsing** (`SerialSession.parse()`, module-level `sdev.parse()`) — returns `ParseResult` with structured lines and optional regex matching (issue #2)
- Expanded test coverage from 8 to 20 tests

## Test plan
- [x] `python -m pytest tests/test_sdev.py -v` — 20/20 tests pass
- [ ] Test against real serial device once available