### PR TITLE
fix: clean serial output and fix build backend

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = ["setuptools>=64"]
-build-backend = "setuptools.backends._legacy:_Backend"
+build-backend = "setuptools.build_meta"
 
 [project]
 name = "sdev"

--- a/sdev/__init__.py
+++ b/sdev/__init__.py
@@ -18,7 +18,6 @@ CLI::
     sdev -p "ls /proc/meminfo"          # uses saved defaults
 """
 
-import os
 import time
 import re
 import serial
@@ -196,8 +195,8 @@ class SerialSession:
     ) -> Iterator[str]:
         """Yield output incrementally as it arrives.
 
-        Suitable for long-running commands or large output where buffering
-        the entire transcript in memory is impractical.
+        Echoed command text is stripped from the first chunk.
+        Trailing prompt is not yielded.
 
         Yields decoded string chunks.  Stops when *timeout* elapses.
 
@@ -212,6 +211,7 @@ class SerialSession:
         ser.flush()
 
         buf = bytearray()
+        echo_stripped = False
         while True:
             remaining = deadline - (time.monotonic() - start)
             if remaining <= 0:
@@ -220,11 +220,27 @@ class SerialSession:
             chunk = ser.read(chunk_size)
             if chunk:
                 buf.extend(chunk)
+                has_prompt = _prompt_detected(bytes(buf))
+
+                # Strip echoed command from first yield
+                if not echo_stripped:
+                    full = bytes(buf)
+                    clean = _strip_echo(full, command)
+                    if clean != full:
+                        chunk = clean
+                        echo_stripped = True
+
                 text = chunk.decode(errors="replace")
+
+                # If prompt detected, strip it from the last chunk before yielding
+                if has_prompt:
+                    text = _strip_prompt(chunk).decode(errors="replace")
+
                 if filter_fn:
                     text = filter_fn(text)
-                yield text
-                if _prompt_detected(bytes(buf)):
+                if text:
+                    yield text
+                if has_prompt:
                     break
             else:
                 time.sleep(min(0.1, remaining))

--- a/sdev/__init__.py
+++ b/sdev/__init__.py
@@ -195,7 +195,7 @@ class SerialSession:
     ) -> Iterator[str]:
         """Yield output incrementally as it arrives.
 
-        Echoed command text is stripped from the first chunk.
+        Echoed command text is stripped from the first chunk(s).
         Trailing prompt is not yielded.
 
         Yields decoded string chunks.  Stops when *timeout* elapses.
@@ -211,6 +211,7 @@ class SerialSession:
         ser.flush()
 
         buf = bytearray()
+        offset = 0  # how far into buf we've already yielded
         echo_stripped = False
         while True:
             remaining = deadline - (time.monotonic() - start)
@@ -222,26 +223,42 @@ class SerialSession:
                 buf.extend(chunk)
                 has_prompt = _prompt_detected(bytes(buf))
 
-                # Strip echoed command from first yield
                 if not echo_stripped:
-                    full = bytes(buf)
-                    clean = _strip_echo(full, command)
-                    if clean != full:
-                        chunk = clean
-                        echo_stripped = True
+                    clean = _strip_echo(bytes(buf), command)
+                    echo_prefix = len(buf) - len(clean)
+                    # The echo is either fully found or absent; mark done either way
+                    echo_stripped = True
+                    if has_prompt:
+                        clean = _strip_prompt(clean)
+                    # Yield everything from echo_prefix onward that we haven't yet
+                    new_data = clean[echo_prefix:]
+                    text = new_data.decode(errors="replace")
+                    if filter_fn:
+                        text = filter_fn(text)
+                    if text:
+                        yield text
+                    if has_prompt:
+                        break
+                    offset = len(buf)
+                    continue
 
-                text = chunk.decode(errors="replace")
-
-                # If prompt detected, strip it from the last chunk before yielding
+                # Echo already handled — yield only new bytes since last yield
                 if has_prompt:
-                    text = _strip_prompt(chunk).decode(errors="replace")
+                    new_data = _strip_prompt(bytes(buf[offset:]))
+                    text = new_data.decode(errors="replace")
+                    if filter_fn:
+                        text = filter_fn(text)
+                    if text:
+                        yield text
+                    break
 
+                new_data = bytes(buf[offset:])
+                text = new_data.decode(errors="replace")
                 if filter_fn:
                     text = filter_fn(text)
                 if text:
                     yield text
-                if has_prompt:
-                    break
+                offset = len(buf)
             else:
                 time.sleep(min(0.1, remaining))
 

--- a/sdev/__init__.py
+++ b/sdev/__init__.py
@@ -68,6 +68,24 @@ class ParseResult:
 PROMPTS = [b"# ", b"$ ", b"> ", b"~# ", b"~$ "]
 
 
+def _strip_prompt(buf: bytes) -> bytes:
+    """Remove a trailing shell prompt from *buf*, if present."""
+    stripped = buf.rstrip(b"\r\n")
+    for p in PROMPTS:
+        if stripped.endswith(p):
+            return stripped[: -len(p)]
+    return buf
+
+
+def _strip_echo(buf: bytes, command: str) -> bytes:
+    """Remove the echoed command text from the start of *buf*."""
+    cmd = command.encode()
+    for ending in (b"\r\n", b"\n", b"\r"):
+        if buf.startswith(cmd + ending):
+            return buf[len(cmd) + len(ending):]
+    return buf
+
+
 def _prompt_detected(buf: bytes) -> bool:
     """Return True if a known shell prompt appears at the tail of *buf*."""
     stripped = buf.rstrip(b"\r\n")
@@ -159,9 +177,12 @@ class SerialSession:
                 time.sleep(min(0.1, remaining))
 
         elapsed = time.monotonic() - start
+        clean = bytes(buf)
+        clean = _strip_echo(clean, command)
+        clean = _strip_prompt(clean)
         return SerialResult(
             command=command,
-            output=bytes(buf).decode(errors="replace"),
+            output=clean.decode(errors="replace"),
             timed_out=timed_out,
             elapsed=round(elapsed, 2),
         )
@@ -190,6 +211,7 @@ class SerialSession:
         ser.write((command + "\n").encode())
         ser.flush()
 
+        buf = bytearray()
         while True:
             remaining = deadline - (time.monotonic() - start)
             if remaining <= 0:
@@ -197,11 +219,12 @@ class SerialSession:
 
             chunk = ser.read(chunk_size)
             if chunk:
+                buf.extend(chunk)
                 text = chunk.decode(errors="replace")
                 if filter_fn:
                     text = filter_fn(text)
                 yield text
-                if _prompt_detected(chunk):
+                if _prompt_detected(bytes(buf)):
                     break
             else:
                 time.sleep(min(0.1, remaining))

--- a/sdev/__init__.py
+++ b/sdev/__init__.py
@@ -64,7 +64,7 @@ class ParseResult:
 # Prompt detection
 # ---------------------------------------------------------------------------
 
-PROMPTS = [b"# ", b"$ ", b"> ", b"~# ", b"~$ "]
+PROMPTS = [b"~# ", b"~$ ", b"# ", b"$ ", b"> "]
 
 
 def _strip_prompt(buf: bytes) -> bytes:

--- a/sdev/__init__.py
+++ b/sdev/__init__.py
@@ -211,8 +211,8 @@ class SerialSession:
         ser.flush()
 
         buf = bytearray()
-        offset = 0  # how far into buf we've already yielded
-        echo_stripped = False
+        consumed = 0  # bytes of buf already processed (echo + yielded)
+        echo_skip = 0  # leading bytes to skip (echoed command)
         while True:
             remaining = deadline - (time.monotonic() - start)
             if remaining <= 0:
@@ -223,42 +223,26 @@ class SerialSession:
                 buf.extend(chunk)
                 has_prompt = _prompt_detected(bytes(buf))
 
-                if not echo_stripped:
+                # Resolve echo skip length once
+                if echo_skip == 0:
                     clean = _strip_echo(bytes(buf), command)
-                    echo_prefix = len(buf) - len(clean)
-                    # The echo is either fully found or absent; mark done either way
-                    echo_stripped = True
-                    if has_prompt:
-                        clean = _strip_prompt(clean)
-                    # Yield everything from echo_prefix onward that we haven't yet
-                    new_data = clean[echo_prefix:]
-                    text = new_data.decode(errors="replace")
-                    if filter_fn:
-                        text = filter_fn(text)
-                    if text:
-                        yield text
-                    if has_prompt:
-                        break
-                    offset = len(buf)
-                    continue
+                    echo_skip = len(buf) - len(clean)
 
-                # Echo already handled — yield only new bytes since last yield
+                # New data starts after what we've already consumed and the echo
+                start_pos = max(consumed, echo_skip)
+                new_data = bytes(buf[start_pos:])
                 if has_prompt:
-                    new_data = _strip_prompt(bytes(buf[offset:]))
-                    text = new_data.decode(errors="replace")
-                    if filter_fn:
-                        text = filter_fn(text)
-                    if text:
-                        yield text
-                    break
+                    new_data = _strip_prompt(new_data)
 
-                new_data = bytes(buf[offset:])
                 text = new_data.decode(errors="replace")
                 if filter_fn:
                     text = filter_fn(text)
                 if text:
                     yield text
-                offset = len(buf)
+
+                consumed = len(buf)
+                if has_prompt:
+                    break
             else:
                 time.sleep(min(0.1, remaining))
 

--- a/tests/test_adversarial_strip.py
+++ b/tests/test_adversarial_strip.py
@@ -24,15 +24,19 @@ class TestStripPromptEdgeCases(unittest.TestCase):
         result = sdev._strip_prompt(b"output# ")
         self.assertEqual(result, b"output")
 
-    def test_compound_prompt_longer_match_first(self):
-        """Compound prompts like ~# should be stripped as a whole, not leaving '~'.
+    def test_compound_prompt_stripped_whole(self):
+        """Compound prompts like ~# should be stripped as a whole.
 
-        BUG: _strip_prompt checks '# ' before '~# ' in PROMPTS order,
-        so '~# ' is partially stripped, leaving a dangling '~'.
+        FIXED in commit fa61e54: PROMPTS reordered to check compound prompts first.
         """
         result = sdev._strip_prompt(b"out~# ")
-        # Expected: b"out". Actual (buggy): b"out~" because '# ' matches first.
-        self.assertEqual(result, b"out~")
+        self.assertEqual(result, b"out")
+
+    def test_all_prompt_variants_stripped(self):
+        """Every prompt in PROMPTS should be fully stripped."""
+        for p in sdev.PROMPTS:
+            result = sdev._strip_prompt(b"out" + p)
+            self.assertEqual(result, b"out", f"Failed for prompt {p!r}")
 
 
 class TestStripEchoEdgeCases(unittest.TestCase):

--- a/tests/test_adversarial_strip.py
+++ b/tests/test_adversarial_strip.py
@@ -1,0 +1,112 @@
+"""Adversarial tests for echo/prompt stripping — test-owned coverage."""
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+import sdev
+
+
+class TestStripPromptEdgeCases(unittest.TestCase):
+    """Edge cases for _strip_prompt not covered by dev's tests."""
+
+    def test_removes_crlf_before_prompt(self):
+        """Prompt preceded by \\r\\n should strip cleanly."""
+        self.assertEqual(
+            sdev._strip_prompt(b"output\r\n$ "),
+            b"output\r\n"
+        )
+
+    def test_text_ending_like_prompt_is_stripped(self):
+        """Text ending with a known prompt pattern gets stripped — this is by design.
+        If real device output legitimately ends with '# ', it will be removed.
+        This is acceptable since '# ' is a real shell prompt indicator.
+        """
+        result = sdev._strip_prompt(b"output# ")
+        self.assertEqual(result, b"output")
+
+    def test_compound_prompt_longer_match_first(self):
+        """Compound prompts like ~# should be stripped as a whole, not leaving '~'.
+
+        BUG: _strip_prompt checks '# ' before '~# ' in PROMPTS order,
+        so '~# ' is partially stripped, leaving a dangling '~'.
+        """
+        result = sdev._strip_prompt(b"out~# ")
+        # Expected: b"out". Actual (buggy): b"out~" because '# ' matches first.
+        self.assertEqual(result, b"out~")
+
+
+class TestStripEchoEdgeCases(unittest.TestCase):
+    """Edge cases for _strip_echo not covered by dev's tests."""
+
+    def test_partial_command_not_stripped(self):
+        """Command that is a prefix of the buffer should not be stripped."""
+        self.assertEqual(
+            sdev._strip_echo(b"echo high\nresult\n# ", "echo hi"),
+            b"echo high\nresult\n# "
+        )
+
+    def test_empty_command_no_crash(self):
+        """Empty command should not strip anything."""
+        self.assertEqual(
+            sdev._strip_echo(b"some output\n# ", ""),
+            b"some output\n# "
+        )
+
+    def test_command_appears_mid_buffer(self):
+        """Command text appearing mid-buffer should not be stripped."""
+        self.assertEqual(
+            sdev._strip_echo(b"prefix: echo hi\nresult\n# ", "echo hi"),
+            b"prefix: echo hi\nresult\n# "
+        )
+
+
+class TestStreamPromptSpanningChunkBoundary(unittest.TestCase):
+    """Guard: prompt that spans two chunks should still be stripped."""
+
+    def test_prompt_spanning_chunks_not_in_output(self):
+        """If prompt ' # ' is split across chunks, final yield should not include it."""
+        mock_ser = MagicMock()
+        mock_ser.is_open = True
+        mock_ser.read.side_effect = [b"hello worl", b"d\n# ", b""]
+
+        sess = sdev.SerialSession()
+        sess._connection = mock_ser
+
+        chunks = list(sess.stream("echo hello world"))
+        combined = "".join(chunks)
+        self.assertNotIn("# ", combined, "Prompt leaked into stream output")
+
+
+class TestCLIOutputCleansing(unittest.TestCase):
+    """Verify cli() output does not contain echo or prompt."""
+
+    def test_cli_strips_echo_and_prompt(self):
+        """cli() result should not contain the echoed command or trailing prompt."""
+        mock_ser = MagicMock()
+        mock_ser.is_open = True
+        mock_ser.read.side_effect = [b"echo test\nhello world\n# ", b""]
+
+        sess = sdev.SerialSession()
+        sess._connection = mock_ser
+
+        result = sess.cli("echo test")
+        self.assertNotIn("echo test", result.output)
+        self.assertNotIn("# ", result.output)
+        self.assertIn("hello world", result.output)
+
+    def test_cli_strips_echo_with_crlf(self):
+        """Some devices echo with \\r\\n instead of \\n."""
+        mock_ser = MagicMock()
+        mock_ser.is_open = True
+        mock_ser.read.side_effect = [b"cmd\r\nok\r\n# ", b""]
+
+        sess = sdev.SerialSession()
+        sess._connection = mock_ser
+
+        result = sess.cli("cmd")
+        self.assertNotIn("cmd", result.output)
+        self.assertIn("ok", result.output)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_sdev.py
+++ b/tests/test_sdev.py
@@ -57,6 +57,22 @@ class TestPromptDetection(unittest.TestCase):
         self.assertFalse(sdev._prompt_detected(b"some random output"))
 
 
+class TestStripPrompt(unittest.TestCase):
+    def test_removes_trailing_prompt(self):
+        self.assertEqual(sdev._strip_prompt(b"output\n# "), b"output\n")
+
+    def test_leaves_promptless(self):
+        self.assertEqual(sdev._strip_prompt(b"just output"), b"just output")
+
+
+class TestStripEcho(unittest.TestCase):
+    def test_removes_echoed_command(self):
+        self.assertEqual(sdev._strip_echo(b"echo hi\nresult\n# ", "echo hi"), b"result\n# ")
+
+    def test_no_match(self):
+        self.assertEqual(sdev._strip_echo(b"result\n# ", "echo hi"), b"result\n# ")
+
+
 class TestSerialSession(unittest.TestCase):
     def test_init_defaults(self):
         sess = sdev.SerialSession()
@@ -134,7 +150,7 @@ class TestSerialSession(unittest.TestCase):
         sess._connection = mock_ser
 
         r = sess.parse("cat file")
-        self.assertEqual(r.lines, ["line1", "line2", "# "])
+        self.assertEqual(r.lines, ["line1", "line2"])
         self.assertEqual(r.matched, [])
 
     def test_parse_with_pattern(self):

--- a/tests/test_sdev.py
+++ b/tests/test_sdev.py
@@ -128,7 +128,7 @@ class TestSerialSession(unittest.TestCase):
         sess._connection = mock_ser
 
         chunks = list(sess.stream("echo hello world"))
-        self.assertEqual(chunks, ["hello ", "world\n# "])
+        self.assertEqual(chunks, ["hello ", "world\n"])
 
     def test_stream_timeout(self):
         mock_ser = MagicMock()


### PR DESCRIPTION
## Summary
- Fix `SerialSession.stream` prompt detection to use cumulative buffer instead of per-chunk, preventing missed prompts that span chunk boundaries
- Strip echoed command text and trailing shell prompt from both `cli()` and `stream()` results so callers get only the command response
- Fix `pyproject.toml` build-backend from invalid `setuptools.backends._legacy` to `setuptools.build_meta` (resolves issue #7)
- Add tests for `_strip_prompt` and `_strip_echo`

## Test plan
- [x] `python -m pytest tests/test_sdev.py -v` — 28 passed
- [x] `pip install -e .` succeeds

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>