### PR TITLE
fix: wrap run() connect in try/finally + update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@ sdev -p "ls /proc/meminfo" -d /dev/ttyUSB0 -b 115200
 # Stream output incrementally
 sdev -p "tail -f /var/log/syslog" --stream
 
+# Stream with server-side regex filter
+sdev -p "tail -f /var/log/syslog" --stream --grep "ERROR"
+
 # Parse output with regex
 sdev -p "cat /proc/meminfo" --parse "Mem.*"
 
@@ -51,6 +54,30 @@ sdev -p "ls /proc/meminfo"
 - **Predictability**: prompt detection to determine command completion
 - **Streaming**: incremental output for long-running commands
 - **Parsing**: structured output with optional regex filtering
+
+## Python API
+
+```python
+import sdev
+
+# Session-based (recommended)
+with sdev.SerialSession("/dev/ttyUSB0", 115200) as session:
+    result = session.cli("ls /proc/meminfo")
+    print(result.output)
+
+# Streaming for long-running commands
+for chunk in session.stream("tail -f /var/log/syslog"):
+    print(chunk, end="")
+
+# Parsing with regex filtering
+parsed = session.parse("cat /proc/meminfo", pattern=r"Mem.*")
+print(parsed.matched)
+
+# Module-level convenience API
+sdev.connect("/dev/ttyUSB0", 115200)
+result = sdev.cli("ls /proc/meminfo")
+sdev.disconnect()
+```
 
 ## License
 

--- a/sdev/__init__.py
+++ b/sdev/__init__.py
@@ -353,8 +353,8 @@ def cli(command: str, timeout: Optional[float] = None) -> SerialResult:
 def run(device: str, baud: int, command: str, timeout: Optional[float] = None) -> SerialResult:
     """Open connection, run *command*, close. One-shot helper."""
     session = SerialSession(device, baud)
-    session.connect()
     try:
+        session.connect()
         return session.cli(command, timeout)
     finally:
         session.close()

--- a/tests/test_adversarial_run_connect.py
+++ b/tests/test_adversarial_run_connect.py
@@ -1,0 +1,56 @@
+"""Adversarial tests for run() connect-in-try fix — test-owned coverage."""
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+import serial
+
+import sdev
+
+
+class TestRunConnectInTry(unittest.TestCase):
+    """Guard: run() must close session even if connect() fails."""
+
+    def test_run_closes_on_connect_failure(self):
+        """run() should call close() even when connect() raises RuntimeError."""
+        with patch.object(sdev, "SerialSession") as mock_cls:
+            mock_sess = MagicMock()
+            mock_cls.return_value = mock_sess
+            mock_sess.connect.side_effect = RuntimeError("Cannot open /dev/ttyX: no device")
+
+            with self.assertRaises(RuntimeError):
+                sdev.run("/dev/ttyX", 115200, "echo test")
+
+            mock_sess.connect.assert_called_once()
+            mock_sess.close.assert_called_once()
+
+    def test_run_closes_on_success(self):
+        """run() should call close() on the happy path."""
+        with patch.object(sdev, "SerialSession") as mock_cls:
+            mock_sess = MagicMock()
+            mock_cls.return_value = mock_sess
+            mock_sess.cli.return_value = sdev.SerialResult(
+                "echo ok", "ok\n", False, 0.1)
+
+            result = sdev.run("/dev/ttyS0", 9600, "echo ok")
+
+            self.assertEqual(result.output, "ok\n")
+            mock_sess.connect.assert_called_once()
+            mock_sess.cli.assert_called_once()
+            mock_sess.close.assert_called_once()
+
+    def test_run_close_despite_cli_error(self):
+        """run() should close() even if cli() raises."""
+        with patch.object(sdev, "SerialSession") as mock_cls:
+            mock_sess = MagicMock()
+            mock_cls.return_value = mock_sess
+            mock_sess.cli.side_effect = serial.SerialException("broken")
+
+            with self.assertRaises(serial.SerialException):
+                sdev.run("/dev/ttyS0", 9600, "echo boom")
+
+            mock_sess.close.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Wrap `session.connect()` inside `try` in `run()` so `finally: session.close()` always runs even on connect failure
- Update README: add `--grep` CLI example, show module-level convenience API (`connect`/`disconnect`)

## Test plan
- [x] All 59 existing tests pass

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>