### PR TITLE
feat: add doctor() and wait_for_silence() for board recovery

### DIFF
--- a/sdev/__init__.py
+++ b/sdev/__init__.py
@@ -216,6 +216,70 @@ class SerialSession:
                 pass
             self._connection = None
 
+    def doctor(self, timeout: float = 10) -> None:
+        """Clear stray foreground processes and drain garbage from serial buffer.
+
+        Sends multiple Ctrl+C sequences, then waits for a clean prompt.
+        Useful after a device reboot or when previous commands left
+        interactive programs (top, vi, etc.) running.
+        """
+        if not self.is_open:
+            self.connect()
+        ser = self._ensure_open()
+        deadline = timeout
+        start = time.monotonic()
+        buf = bytearray()
+
+        # Send multiple Ctrl+C to clear foreground jobs
+        for _ in range(3):
+            ser.write(b"\x03")
+            time.sleep(0.2)
+        ser.write(b"\r\n")
+        time.sleep(0.3)
+
+        # Drain buffer until we see a prompt or timeout
+        while True:
+            remaining = deadline - (time.monotonic() - start)
+            if remaining <= 0:
+                return
+            try:
+                chunk = ser.read(4096)
+            except serial.SerialException:
+                return
+            if chunk:
+                buf.extend(chunk)
+                if len(buf) > 65536:
+                    buf = buf[-32768:]
+                if self._check_prompt(bytes(buf)):
+                    return
+            time.sleep(min(0.1, remaining))
+
+    def wait_for_silence(self, timeout: float = 1.5) -> None:
+        """Block until no data arrives on the serial line for *timeout* seconds.
+
+        Useful to ensure the device has finished booting or that a
+        background process has stopped producing output.
+        """
+        if not self.is_open:
+            self.connect()
+        ser = self._ensure_open()
+        deadline = time.monotonic() + 30  # hard cap
+        last_data = time.monotonic()
+
+        while True:
+            now = time.monotonic()
+            if now - last_data >= timeout:
+                return
+            if now > deadline:
+                return
+            try:
+                chunk = ser.read(4096)
+            except serial.SerialException:
+                return
+            if chunk:
+                last_data = now
+            time.sleep(min(0.1, timeout))
+
     def interrupt(self, timeout: Optional[float] = 5) -> bool:
         """Send Ctrl+C to interrupt a running command and wait for the prompt.
 

--- a/tests/test_doctor_silence.py
+++ b/tests/test_doctor_silence.py
@@ -1,0 +1,115 @@
+"""Tests for SerialSession.doctor() and wait_for_silence()."""
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+import sdev
+
+
+class TestDoctor(unittest.TestCase):
+    """doctor() clears stray output and waits for a clean prompt."""
+
+    def test_doctor_sends_ctrl_c_and_returns_on_prompt(self):
+        """doctor() should send Ctrl+C and return when prompt appears."""
+        mock_ser = MagicMock()
+        mock_ser.is_open = True
+        mock_ser.read.side_effect = [
+            b"some garbage\r\n",
+            b"^C\r\n",
+            b"root@board:~# ",
+            b"",
+        ]
+        sess = sdev.SerialSession()
+        sess._connection = mock_ser
+
+        sess.doctor(timeout=2)
+
+        # Should have written Ctrl+C and newline
+        writes = [call.args[0] for call in mock_ser.write.call_args_list]
+        self.assertIn(b"\x03", writes)
+        self.assertIn(b"\r\n", writes)
+
+    def test_doctor_auto_connects(self):
+        """doctor() should auto-connect if not already open."""
+        with patch("sdev.serial.Serial") as mock_cls:
+            mock_ser = mock_cls.return_value
+            mock_ser.is_open = True
+            mock_ser.read.side_effect = [b"# ", b""]
+
+            sess = sdev.SerialSession()
+            sess.doctor(timeout=1)
+
+            mock_cls.assert_called_once()
+            mock_ser.close.assert_not_called()
+
+    def test_doctor_returns_on_timeout_no_prompt(self):
+        """doctor() should return without error even if no prompt appears."""
+        mock_ser = MagicMock()
+        mock_ser.is_open = True
+        mock_ser.read.side_effect = [b"garbage\n", b"", b""]
+        sess = sdev.SerialSession()
+        sess._connection = mock_ser
+
+        # Should not raise
+        sess.doctor(timeout=0.3)
+
+    def test_doctor_trims_buffer(self):
+        """doctor() should trim buffer if it exceeds 64KB."""
+        mock_ser = MagicMock()
+        mock_ser.is_open = True
+        # First chunk is large, second has prompt
+        mock_ser.read.side_effect = [
+            b"x" * 40000,
+            b"y" * 40000,
+            b"# ",
+        ]
+        sess = sdev.SerialSession()
+        sess._connection = mock_ser
+
+        sess.doctor(timeout=2)
+
+
+class TestWaitForSilence(unittest.TestCase):
+    """wait_for_silence() blocks until no data arrives for N seconds."""
+
+    def test_returns_when_silence_detected(self):
+        """Should return after no data arrives for the timeout period."""
+        mock_ser = MagicMock()
+        mock_ser.is_open = True
+        mock_ser.read.side_effect = [
+            b"boot log\n",
+            b"",
+            b"",
+            b"",
+            b"",
+            b"",
+        ]
+        sess = sdev.SerialSession()
+        sess._connection = mock_ser
+
+        sess.wait_for_silence(timeout=0.2)
+
+    def test_returns_on_serial_error(self):
+        """Should return without error on serial exception."""
+        mock_ser = MagicMock()
+        mock_ser.is_open = True
+        import serial
+        mock_ser.read.side_effect = serial.SerialException("lost")
+        sess = sdev.SerialSession()
+        sess._connection = mock_ser
+
+        sess.wait_for_silence(timeout=0.2)
+
+    def test_auto_connects_if_not_open(self):
+        """wait_for_silence() should auto-connect if not already open."""
+        with patch("sdev.serial.Serial") as mock_cls:
+            mock_ser = mock_cls.return_value
+            mock_ser.is_open = True
+            mock_ser.read.side_effect = [b"", b""]
+            sess = sdev.SerialSession()
+            sess.wait_for_silence(timeout=0.2)
+            mock_cls.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- **`doctor(timeout=10)`**: sends 3× Ctrl+C + newline, drains serial buffer until a clean prompt appears. Auto-connects if not open. Useful after device reboot or when stray foreground processes (top, vi) are running.
- **`wait_for_silence(timeout=1.5)`**: blocks until no data arrives on the serial line for the specified duration. Useful to detect boot completion or background process quiescence. Auto-connects if not open.
- **7 new tests** in `tests/test_doctor_silence.py`
- All 136 tests pass

Addresses part of #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)