### PR TITLE
feat: add --end-flag, --line-mode, and --doctor CLI flags

### DIFF
--- a/sdev/__main__.py
+++ b/sdev/__main__.py
@@ -70,6 +70,21 @@ def main() -> None:
         help="Send Ctrl+C to interrupt a running command on the serial line "
              "and wait for the prompt. Use without -p.",
     )
+    parser.add_argument(
+        "--end-flag",
+        metavar="MARKER",
+        help="Stop waiting for output when this string appears (instead of shell prompt).",
+    )
+    parser.add_argument(
+        "--line-mode",
+        action="store_true",
+        help="During --stream, yield complete lines only (buffer partial lines).",
+    )
+    parser.add_argument(
+        "--doctor",
+        action="store_true",
+        help="Clear stray foreground processes and drain garbage before running a command.",
+    )
 
     sub = parser.add_subparsers(dest="subcommand")
     set_parser = sub.add_parser(
@@ -112,6 +127,9 @@ def main() -> None:
     prompt_bytes = [p.encode() for p in args.prompts] if args.prompts else None
 
     with sdev.SerialSession(device, baud, prompts=prompt_bytes) as sess:
+        if args.doctor:
+            sess.doctor()
+
         if args.stream:
             if args.grep:
                 _regex = re.compile(args.grep)
@@ -128,7 +146,13 @@ def main() -> None:
             else:
                 filter_fn = None
 
-            for chunk in sess.stream(args.command, timeout=args.timeout, filter_fn=filter_fn):
+            for chunk in sess.stream(
+                args.command,
+                timeout=args.timeout,
+                filter_fn=filter_fn,
+                line_mode=args.line_mode,
+                end_flag=args.end_flag,
+            ):
                 sys.stdout.write(chunk)
             sys.stdout.flush()
         elif args.parse:
@@ -140,7 +164,7 @@ def main() -> None:
                 print("(no matches)", file=sys.stderr)
                 sys.exit(3)
         else:
-            result = sess.cli(args.command, timeout=args.timeout)
+            result = sess.cli(args.command, timeout=args.timeout, end_flag=args.end_flag)
             if result.output:
                 sys.stdout.write(result.output)
             if result.timed_out:

--- a/tests/test_adversarial_timeout.py
+++ b/tests/test_adversarial_timeout.py
@@ -104,7 +104,7 @@ class TestCLIEntrypointTimeout(unittest.TestCase):
                  unittest.mock.patch("sdev.serial.Serial", return_value=mock_ser):
                 main()
 
-            mock_sess.cli.assert_called_once_with("echo ok", timeout=0.5)
+            mock_sess.cli.assert_called_once_with("echo ok", timeout=0.5, end_flag=None)
 
     def test_stream_mode_timeout(self):
         """Stream mode passes timeout to stream()."""
@@ -132,7 +132,7 @@ class TestCLIEntrypointTimeout(unittest.TestCase):
                 main()
 
             mock_sess.stream.assert_called_once_with(
-                "echo ok", timeout=10.0, filter_fn=None)
+                "echo ok", timeout=10.0, filter_fn=None, line_mode=False, end_flag=None)
 
     def test_parse_mode_timeout(self):
         """Parse mode passes timeout to parse()."""


### PR DESCRIPTION
## Summary
- **`--end-flag=MARKER`**: stop waiting when this output marker appears (instead of shell prompt)
- **`--line-mode`**: during `--stream`, yield complete lines only (buffers partial lines across chunks)
- **`--doctor`**: clear stray foreground processes and drain garbage before running command

All 148 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)