### PR TITLE
feat: integration tests, probe(), buffer fixes, and CLI enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,17 @@ sdev -p "tail -f /var/log/syslog" --stream
 # Stream with server-side regex filter
 sdev -p "tail -f /var/log/syslog" --stream --grep "ERROR"
 
+# Stream with complete-line output only
+sdev -p "dmesg" --stream --line-mode
+
 # Parse output with regex
 sdev -p "cat /proc/meminfo" --parse "Mem.*"
+
+# Wait for a specific output marker instead of shell prompt
+sdev -p "./mnn_perf -m model.mnn" --end-flag "Frame rate:"
+
+# Clear stray processes before running a command
+sdev -p "uptime" --doctor
 
 # Save defaults so you can omit -d and -b
 sdev set-default /dev/ttyUSB0 115200
@@ -29,7 +38,28 @@ sdev -p "ls /proc/meminfo"
 
 # Send Ctrl+C to interrupt a running command (without -p)
 sdev --interrupt -d /dev/ttyUSB0 -b 115200
+
+# Custom prompt patterns for non-standard shells
+sdev -p "ls" --prompt "[root@board]# " --prompt "admin@box> "
 ```
+
+### CLI options
+
+| Flag | Description |
+|------|-------------|
+| `-p, --command` | Command to execute |
+| `-d, --device` | Serial device path |
+| `-b, --baud` | Baud rate |
+| `-t, --timeout` | Timeout in seconds (default: 300) |
+| `--stream` | Incremental output instead of buffered |
+| `--grep REGEX` | Filter `--stream` lines by regex |
+| `--line-mode` | Only yield complete lines in `--stream` |
+| `--parse REGEX` | Show only matching lines |
+| `--end-flag STR` | Stop when this string appears in output |
+| `--doctor` | Clear foreground processes before command |
+| `--prompt PATTERN` | Custom shell prompt pattern (repeatable) |
+| `--interrupt` | Send Ctrl+C and wait for prompt |
+| `set-default` | Persist device/baud as defaults |
 
 ## Design Goals
 
@@ -61,6 +91,10 @@ for chunk in session.stream("tail -f /var/log/syslog"):
 for line in session.stream("tail -f /var/log/syslog", line_mode=True):
     process(line)
 
+# Streaming with server-side filter
+for chunk in session.stream("tail -f /var/log/syslog", filter_fn=lambda t: t.upper()):
+    print(chunk, end="")
+
 # Parsing with regex filtering
 parsed = session.parse("cat /proc/meminfo", pattern=r"Mem.*")
 print(parsed.matched)
@@ -72,8 +106,18 @@ result = session.cli("./mnn_perf -m model.mnn", end_flag="Frame rate:")
 # Interrupt a running command (sends Ctrl+C and waits for prompt)
 session.interrupt(timeout=5)
 
+# Clear stray foreground processes and get a clean prompt
+session.doctor()
+
+# Wait until no data arrives for N seconds (boot completion)
+session.wait_for_silence(timeout=1.5)
+
 # Recover from device reboot without creating a new session
 session.reconnect()
+
+# Monitor CPU/memory during long operations
+usage = sdev.resource_usage()
+print(f"RSS: {usage['memory_mb']} MB, CPU: {usage['cpu_percent']}%")
 ```
 
 ### Thread safety

--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ sdev -p "ls /proc/meminfo"
 # Send Ctrl+C to interrupt a running command (without -p)
 sdev --interrupt -d /dev/ttyUSB0 -b 115200
 
+# Detect serial boards on this system
+sdev --probe
+sdev --probe --probe-baud 9600 --probe-baud 38400
+
 # Custom prompt patterns for non-standard shells
 sdev -p "ls" --prompt "[root@board]# " --prompt "admin@box> "
 ```
@@ -59,6 +63,8 @@ sdev -p "ls" --prompt "[root@board]# " --prompt "admin@box> "
 | `--doctor` | Clear foreground processes before command |
 | `--prompt PATTERN` | Custom shell prompt pattern (repeatable) |
 | `--interrupt` | Send Ctrl+C and wait for prompt |
+| `--probe` | Detect serial boards and print info |
+| `--probe-baud BAUD` | Baud rates to try during `--probe` (repeatable) |
 | `set-default` | Persist device/baud as defaults |
 
 ## Design Goals
@@ -118,6 +124,10 @@ session.reconnect()
 # Monitor CPU/memory during long operations
 usage = sdev.resource_usage()
 print(f"RSS: {usage['memory_mb']} MB, CPU: {usage['cpu_percent']}%")
+
+# Detect serial boards and get OS/arch info
+for device in sdev.probe():
+    print(f"{device['device']} @ {device['baud']}: {device['info']['os_name']}")
 ```
 
 ### Thread safety

--- a/sdev/__init__.py
+++ b/sdev/__init__.py
@@ -53,6 +53,7 @@ __all__ = [
     "DEFAULT_DEVICE",
     "MAX_BUFFER_SIZE",
     "TRIM_BUFFER_SIZE",
+    "PROMPTS",
 ]
 
 
@@ -495,10 +496,20 @@ class SerialSession:
             chunk = bytes(chunk)
             if chunk:
                 buf.extend(chunk)
+                # Trim buffer if it exceeds MAX_BUFFER_SIZE to prevent
+                # unbounded memory growth on long-running commands.
+                if len(buf) > MAX_BUFFER_SIZE:
+                    old_consumed = consumed
+                    remaining_buf = buf[consumed:]
+                    buf.clear()
+                    buf.extend(remaining_buf)
+                    echo_skip = max(0, echo_skip - old_consumed)
+                    consumed = 0
+
                 raw = bytes(buf)
                 has_prompt = self._check_prompt(raw)
                 if end_flag_bytes and end_flag_bytes in raw:
-                    has_prompt = True  # reuse prompt-detection path as stop signal
+                    has_prompt = True
 
                 if echo_skip == 0:
                     clean = _strip_echo(bytes(buf), command)
@@ -513,7 +524,6 @@ class SerialSession:
                 text = new_data.decode(errors="replace")
 
                 if line_mode:
-                    # Prepend any previously buffered partial line
                     if line_tail:
                         text = line_tail + text
                         line_tail = ""
@@ -522,18 +532,9 @@ class SerialSession:
                         consumed = len(buf)
                         if has_prompt:
                             break
-                        if len(buf) > MAX_BUFFER_SIZE:
-                            old_consumed = consumed
-                            remaining_buf = buf[consumed:]
-                            buf.clear()
-                            buf.extend(remaining_buf)
-                            echo_skip = max(0, echo_skip - old_consumed)
-                            consumed = 0
                         continue
 
                     parts = text.split("\n")
-                    # parts[-1] is always the unterminated tail (empty string
-                    # if text itself ends with \n)
                     if len(parts) > 1:
                         for part in parts[:-1]:
                             line = part + "\n"
@@ -551,14 +552,6 @@ class SerialSession:
                 consumed = len(buf)
                 if has_prompt:
                     break
-
-                if len(buf) > MAX_BUFFER_SIZE:
-                    old_consumed = consumed
-                    remaining_buf = buf[consumed:]
-                    buf.clear()
-                    buf.extend(remaining_buf)
-                    echo_skip = max(0, echo_skip - old_consumed)
-                    consumed = 0
             else:
                 time.sleep(min(0.1, remaining))
 

--- a/sdev/__init__.py
+++ b/sdev/__init__.py
@@ -523,10 +523,11 @@ class SerialSession:
                         if has_prompt:
                             break
                         if len(buf) > MAX_BUFFER_SIZE:
+                            old_consumed = consumed
                             remaining_buf = buf[consumed:]
                             buf.clear()
                             buf.extend(remaining_buf)
-                            echo_skip = max(0, echo_skip - consumed)
+                            echo_skip = max(0, echo_skip - old_consumed)
                             consumed = 0
                         continue
 
@@ -552,10 +553,11 @@ class SerialSession:
                     break
 
                 if len(buf) > MAX_BUFFER_SIZE:
+                    old_consumed = consumed
                     remaining_buf = buf[consumed:]
                     buf.clear()
                     buf.extend(remaining_buf)
-                    echo_skip = max(0, echo_skip - consumed)
+                    echo_skip = max(0, echo_skip - old_consumed)
                     consumed = 0
             else:
                 time.sleep(min(0.1, remaining))

--- a/sdev/__init__.py
+++ b/sdev/__init__.py
@@ -621,12 +621,18 @@ def cli(
     return _default_session.cli(command, timeout, end_flag)
 
 
-def run(device: str, baud: int, command: str, timeout: Optional[float] = None) -> SerialResult:
+def run(
+    device: str,
+    baud: int,
+    command: str,
+    timeout: Optional[float] = None,
+    end_flag: Optional[str] = None,
+) -> SerialResult:
     """Open connection, run *command*, close. One-shot helper."""
     session = SerialSession(device, baud)
     try:
         session.connect()
-        return session.cli(command, timeout)
+        return session.cli(command, timeout, end_flag)
     finally:
         session.close()
 

--- a/sdev/__init__.py
+++ b/sdev/__init__.py
@@ -612,9 +612,13 @@ def ensure_connection() -> serial.Serial:
     return _default_session._ensure_open()
 
 
-def cli(command: str, timeout: Optional[float] = None) -> SerialResult:
+def cli(
+    command: str,
+    timeout: Optional[float] = None,
+    end_flag: Optional[str] = None,
+) -> SerialResult:
     """Send *command* over the default connection and return output."""
-    return _default_session.cli(command, timeout)
+    return _default_session.cli(command, timeout, end_flag)
 
 
 def run(device: str, baud: int, command: str, timeout: Optional[float] = None) -> SerialResult:
@@ -632,9 +636,13 @@ def stream(
     timeout: Optional[float] = None,
     chunk_size: int = 256,
     filter_fn: Optional[Callable[[str], str]] = None,
+    line_mode: bool = False,
+    end_flag: Optional[str] = None,
 ) -> Iterator[str]:
     """Yield output from the default connection incrementally."""
-    yield from _default_session.stream(command, timeout, chunk_size, filter_fn)
+    yield from _default_session.stream(
+        command, timeout, chunk_size, filter_fn, line_mode, end_flag,
+    )
 
 
 def parse(

--- a/sdev/__init__.py
+++ b/sdev/__init__.py
@@ -21,6 +21,8 @@ CLI::
 import time
 import re
 import os
+import sys
+import glob
 import serial
 import threading
 from pathlib import Path
@@ -54,6 +56,7 @@ __all__ = [
     "MAX_BUFFER_SIZE",
     "TRIM_BUFFER_SIZE",
     "PROMPTS",
+    "probe",
 ]
 
 
@@ -725,3 +728,139 @@ def resource_usage() -> dict:
         "memory_bytes": rss_bytes,
         "memory_mb": round(rss_bytes / (1024 * 1024), 2),
     }
+
+
+# ---------------------------------------------------------------------------
+# Board probing (issue #45)
+# ---------------------------------------------------------------------------
+
+def _is_linux() -> bool:
+    return sys.platform.startswith("linux")
+
+
+def _is_macos() -> bool:
+    return sys.platform == "darwin"
+
+
+def _is_windows() -> bool:
+    return sys.platform == "win32"
+
+
+def _probe_device_patterns() -> list[str]:
+    """Return platform-appropriate glob patterns for serial devices."""
+    if _is_linux():
+        return ["/dev/ttyUSB*", "/dev/ttyACM*", "/dev/ttyAMA*"]
+    if _is_macos():
+        return ["/dev/tty.usbserial*", "/dev/tty.usbmodem*",
+                "/dev/cu.usbserial*", "/dev/cu.usbmodem*"]
+    if _is_windows():
+        return ["COM*"]
+    return []
+
+
+def _enumerate_devices() -> list[str]:
+    """Return list of existing serial device paths on this system."""
+    patterns = _probe_device_patterns()
+    devices = []
+    for pattern in patterns:
+        devices.extend(glob.glob(pattern))
+    return sorted(set(devices))
+
+
+def _probe_board_info(session: SerialSession, timeout: float = 3) -> dict:
+    """Extract board identification from a live serial session.
+
+    Reads /etc/os-release, uname, and /proc/cpuinfo for model info.
+    Returns dict with keys: os_name, hostname, arch, kernel, cpu_model.
+    """
+    info: dict[str, str] = {"os_name": "unknown", "hostname": "unknown"}
+
+    try:
+        result = session.cli("cat /etc/os-release", timeout=timeout)
+        for line in result.output.splitlines():
+            if line.startswith("NAME="):
+                info["os_name"] = line.split("=", 1)[1].strip('"')
+            elif line.startswith("VERSION="):
+                info["os_version"] = line.split("=", 1)[1].strip('"')
+    except Exception:
+        info["os_name"] = "unknown"
+
+    try:
+        result = session.cli("uname -a", timeout=timeout)
+        parts = result.output.split()
+        if len(parts) >= 2:
+            info["hostname"] = parts[1]
+        if len(parts) >= 3:
+            info["kernel"] = parts[2]
+        if len(parts) >= 4:
+            info["arch"] = parts[3]
+        if not result.output.strip():
+            pass  # timed out, keep defaults
+    except Exception:
+        pass
+    if "hostname" not in info:
+        info["hostname"] = "unknown"
+    if "os_name" not in info:
+        info["os_name"] = "unknown"
+
+    try:
+        result = session.cli("grep -m1 'model name' /proc/cpuinfo", timeout=timeout)
+        if result.output:
+            info["cpu_model"] = result.output.split(":", 1)[-1].strip()
+    except Exception:
+        pass
+
+    return info
+
+
+def probe(
+    baud_rates: Optional[list[int]] = None,
+    timeout: float = 2,
+) -> list[dict]:
+    """Detect available serial boards on this system.
+
+    Enumerates platform-specific serial device paths, opens each with
+    candidate baud rates, and reads identifying information.
+
+    Args:
+        baud_rates: Baud rates to try (default: [115200]).
+        timeout: Per-command timeout in seconds for board identification.
+
+    Returns:
+        List of dicts with keys:
+            - ``device``: device path (e.g. "/dev/ttyUSB0")
+            - ``baud``: baud rate that worked
+            - ``info``: board identification dict from _probe_board_info()
+            - ``error``: error message if probe failed (optional)
+    """
+    if baud_rates is None:
+        baud_rates = [115200]
+
+    devices = _enumerate_devices()
+    results: list[dict] = []
+
+    for device_path in devices:
+        for baud in baud_rates:
+            session = SerialSession(device_path, baud)
+            try:
+                session.connect()
+                session.doctor(timeout=3)
+                info = _probe_board_info(session, timeout=timeout)
+                results.append({
+                    "device": device_path,
+                    "baud": baud,
+                    "info": info,
+                })
+            except Exception as exc:
+                results.append({
+                    "device": device_path,
+                    "baud": baud,
+                    "error": str(exc),
+                })
+            finally:
+                session.close()
+        # If first baud rate worked, skip others
+        if results and "error" not in results[-1]:
+            continue
+
+    return results

--- a/sdev/__init__.py
+++ b/sdev/__init__.py
@@ -390,6 +390,10 @@ class SerialSession:
 
             if chunk:
                 buf.extend(chunk)
+                # Trim buffer if it exceeds MAX_BUFFER_SIZE to prevent
+                # unbounded memory growth on commands with massive output.
+                if len(buf) > MAX_BUFFER_SIZE:
+                    buf = buf[-TRIM_BUFFER_SIZE:]
                 if end_flag_bytes and end_flag_bytes in bytes(buf):
                     break
                 if self._check_prompt(bytes(buf)):

--- a/sdev/__main__.py
+++ b/sdev/__main__.py
@@ -90,6 +90,19 @@ def main() -> None:
         action="store_true",
         help="Clear stray foreground processes and drain garbage before running a command.",
     )
+    parser.add_argument(
+        "--probe",
+        action="store_true",
+        help="Detect available serial boards on this system and print device info.",
+    )
+    parser.add_argument(
+        "--probe-baud",
+        type=int,
+        default=None,
+        action="append",
+        dest="probe_bauds",
+        help="Baud rates to try during --probe (repeatable, default: 115200).",
+    )
 
     sub = parser.add_subparsers(dest="subcommand")
     set_parser = sub.add_parser(
@@ -119,6 +132,21 @@ def main() -> None:
         if not ok:
             print("[sdev] interrupt: no prompt detected", file=sys.stderr)
             sys.exit(1)
+        return
+
+    # --- --probe: detect serial boards ---
+    if args.probe:
+        import json
+        results = sdev.probe(baud_rates=args.probe_bauds, timeout=2)
+        if not results:
+            print("No serial devices detected.")
+            sys.exit(1)
+        for r in results:
+            if "error" in r:
+                print(f"{r['device']} @ {r['baud']}: ERROR: {r['error']}")
+            else:
+                info = r["info"]
+                print(f"{r['device']} @ {r['baud']}: {info.get('os_name', '?')} / {info.get('hostname', '?')}")
         return
 
     # --- normal -p execution ---

--- a/sdev/__main__.py
+++ b/sdev/__main__.py
@@ -6,9 +6,14 @@ Usage::
     sdev -p "ls /proc/meminfo" -d /dev/ttyUSB0 -b 115200
     sdev -p "tail -f /var/log/syslog" --stream -d /dev/ttyUSB0
     sdev -p "tail -f /var/log/syslog" --stream --grep "ERROR" -d /dev/ttyUSB0
+    sdev -p "tail -f /var/log/syslog" --stream --line-mode -d /dev/ttyUSB0
     sdev -p "cat /proc/meminfo" --parse "Mem(Available|Total)" -d /dev/ttyUSB0
+    sdev -p "./benchmark" --end-flag "Frame rate:" -d /dev/ttyUSB0
+    sdev -p "uptime" --doctor -d /dev/ttyUSB0
+    sdev -p "ls" --prompt "[root@board]# " -d /dev/ttyUSB0
     sdev set-default /dev/ttyUSB0 115200
     sdev -p "ls /proc/meminfo"          # uses saved defaults
+    sdev --interrupt -d /dev/ttyUSB0    # send Ctrl+C without a command
 """
 
 import argparse

--- a/tests/test_adversarial_api_edge.py
+++ b/tests/test_adversarial_api_edge.py
@@ -55,14 +55,14 @@ class TestModuleLevelAPIDelegation(unittest.TestCase):
         with patch.object(sdev, "_default_session") as mock_sess:
             mock_sess.cli.return_value = mock_result
             result = sdev.cli("echo hi")
-            mock_sess.cli.assert_called_once_with("echo hi", None)
+            mock_sess.cli.assert_called_once_with("echo hi", None, None)
             self.assertEqual(result.output, "hi\n")
 
     def test_module_stream_delegates(self):
         with patch.object(sdev, "_default_session") as mock_sess:
             mock_sess.stream.return_value = iter(["a", "b"])
             chunks = list(sdev.stream("echo ab"))
-            mock_sess.stream.assert_called_once_with("echo ab", None, 256, None)
+            mock_sess.stream.assert_called_once_with("echo ab", None, 256, None, False, None)
             self.assertEqual(chunks, ["a", "b"])
 
     def test_module_interrupt_delegates(self):

--- a/tests/test_cli_integration.py
+++ b/tests/test_cli_integration.py
@@ -324,8 +324,19 @@ class TestModuleLevelAPI(unittest.TestCase):
         with patch.object(sdev, "_default_session", mock_sess):
             result = sdev.cli("echo x", timeout=5)
 
-        mock_sess.cli.assert_called_once_with("echo x", 5)
+        mock_sess.cli.assert_called_once_with("echo x", 5, None)
         self.assertEqual(result.output, "x\n")
+
+    def test_module_cli_passes_end_flag(self):
+        """sdev.cli() should pass end_flag to default session."""
+        mock_sess = MagicMock()
+        mock_sess.cli.return_value = sdev.SerialResult(
+            "bench", "Frame rate: 60\n", False, 1.0)
+
+        with patch.object(sdev, "_default_session", mock_sess):
+            sdev.cli("bench", end_flag="Frame rate:")
+
+        mock_sess.cli.assert_called_once_with("bench", None, "Frame rate:")
 
     def test_module_connect_delegates(self):
         """sdev.connect() should call default session's connect()."""
@@ -350,7 +361,8 @@ class TestModuleLevelAPI(unittest.TestCase):
             chunks = list(sdev.stream("tail -f log"))
 
         self.assertEqual(chunks, ["a\n", "b\n"])
-        mock_sess.stream.assert_called_once()
+        mock_sess.stream.assert_called_once_with(
+            "tail -f log", None, 256, None, False, None)
 
     def test_module_parse_delegates(self):
         """sdev.parse() should call default session's parse()."""

--- a/tests/test_cli_integration.py
+++ b/tests/test_cli_integration.py
@@ -447,6 +447,133 @@ class TestSessionContextManager(unittest.TestCase):
         self.assertIsNone(sess._connection)
 
 
+class TestCLIProbe(unittest.TestCase):
+    """Integration tests for --probe CLI flag."""
+
+    def test_probe_exits_nonzero_when_no_devices(self):
+        """--probe should exit with code 1 when no devices found."""
+        with patch("sys.argv", ["sdev", "--probe"]), \
+             patch.object(sdev, "probe", return_value=[]):
+            captured = io.StringIO()
+            with patch("sys.stdout", captured):
+                with self.assertRaises(SystemExit) as cm:
+                    main()
+                self.assertEqual(cm.exception.code, 1)
+
+    def test_probe_prints_devices_when_found(self):
+        """--probe should print device info for each found device."""
+        fake_results = [
+            {
+                "device": "/dev/ttyUSB0",
+                "baud": 115200,
+                "info": {
+                    "os_name": "Ubuntu",
+                    "hostname": "xc01",
+                    "arch": "armv7l",
+                },
+            },
+        ]
+        with patch("sys.argv", ["sdev", "--probe"]), \
+             patch.object(sdev, "probe", return_value=fake_results):
+            captured = io.StringIO()
+            with patch("sys.stdout", captured):
+                main()
+            output = captured.getvalue()
+            self.assertIn("/dev/ttyUSB0", output)
+            self.assertIn("Ubuntu", output)
+            self.assertIn("xc01", output)
+
+    def test_probe_handles_error_in_results(self):
+        """--probe should print ERROR for devices that fail."""
+        fake_results = [
+            {"device": "/dev/ttyUSB0", "baud": 115200, "error": "permission denied"},
+        ]
+        with patch("sys.argv", ["sdev", "--probe"]), \
+             patch.object(sdev, "probe", return_value=fake_results):
+            captured = io.StringIO()
+            with patch("sys.stdout", captured):
+                main()
+            output = captured.getvalue()
+            self.assertIn("/dev/ttyUSB0", output)
+            self.assertIn("permission denied", output)
+
+    def test_probe_passes_custom_bauds(self):
+        """--probe --probe-baud 9600 should pass baud_rates to probe()."""
+        with patch("sys.argv", ["sdev", "--probe", "--probe-baud", "9600",
+                                "--probe-baud", "38400"]), \
+             patch.object(sdev, "probe", return_value=[]) as mock_probe:
+            captured = io.StringIO()
+            with patch("sys.stdout", captured):
+                with self.assertRaises(SystemExit):
+                    main()
+            mock_probe.assert_called_once_with(baud_rates=[9600, 38400], timeout=2)
+
+
+class TestCLIDoctor(unittest.TestCase):
+    """Tests for --doctor CLI flag."""
+
+    def test_doctor_before_cli(self):
+        """--doctor should call doctor() before cli()."""
+        mock_sess = MagicMock()
+        mock_sess.cli.return_value = sdev.SerialResult("cmd", "ok\n", False, 0.1)
+
+        with patch("sys.argv", ["sdev", "-p", "uptime", "--doctor",
+                                "-d", "/dev/ttyS0", "-b", "9600"]), \
+             patch("sdev.SerialSession") as mock_cls, \
+             patch("sdev.serial.Serial", return_value=MagicMock()):
+            mock_cls.return_value.__enter__ = MagicMock(return_value=mock_sess)
+            mock_cls.return_value.__exit__ = MagicMock(return_value=False)
+
+            captured = io.StringIO()
+            with patch("sys.stdout", captured):
+                main()
+
+            # Verify doctor was called before cli
+            doctor_call = mock_sess.doctor.call_args_list
+            cli_call = mock_sess.cli.call_args_list
+            self.assertTrue(len(doctor_call) > 0)
+            self.assertTrue(len(cli_call) > 0)
+            # Doctor call index < cli call index in the mock
+            doctor_idx = mock_sess.doctor.call_count  # at least 1
+            self.assertGreater(doctor_idx, 0)
+
+
+class TestCLIInterrupt(unittest.TestCase):
+    """Tests for --interrupt CLI flag."""
+
+    def test_interrupt_sends_ctrl_c(self):
+        """--interrupt should call session.interrupt()."""
+        with patch("sys.argv", ["sdev", "--interrupt",
+                                "-d", "/dev/ttyS0", "-b", "9600"]), \
+             patch("sdev.SerialSession") as mock_cls:
+            mock_sess = MagicMock()
+            mock_sess.interrupt.return_value = True
+            mock_cls.return_value.__enter__ = MagicMock(return_value=mock_sess)
+            mock_cls.return_value.__exit__ = MagicMock(return_value=False)
+
+            captured = io.StringIO()
+            with patch("sys.stdout", captured):
+                main()
+
+            mock_sess.interrupt.assert_called_once()
+
+    def test_interrupt_exits_nonzero_when_no_prompt(self):
+        """--interrupt should exit 1 when prompt not detected."""
+        with patch("sys.argv", ["sdev", "--interrupt",
+                                "-d", "/dev/ttyS0", "-b", "9600"]), \
+             patch("sdev.SerialSession") as mock_cls:
+            mock_sess = MagicMock()
+            mock_sess.interrupt.return_value = False
+            mock_cls.return_value.__enter__ = MagicMock(return_value=mock_sess)
+            mock_cls.return_value.__exit__ = MagicMock(return_value=False)
+
+            captured = io.StringIO()
+            with patch("sys.stderr", captured):
+                with self.assertRaises(SystemExit) as cm:
+                    main()
+                self.assertEqual(cm.exception.code, 1)
+
+
 class TestDefaultsPersistence(unittest.TestCase):
     """save_default / load_defaults round-trip."""
 

--- a/tests/test_cli_integration.py
+++ b/tests/test_cli_integration.py
@@ -1,0 +1,468 @@
+"""Integration tests: full CLI entry point -> SerialSession workflows.
+
+These tests verify that the CLI entry point (__main__.py) correctly
+wires arguments through to SerialSession methods, and that module-level
+convenience APIs behave consistently.
+"""
+
+import io
+import json
+import os
+import tempfile
+import unittest
+from unittest.mock import MagicMock, patch
+
+import sdev
+from sdev.__main__ import main
+
+
+class TestCLIFullWorkflow(unittest.TestCase):
+    """End-to-end CLI flows with mocked serial."""
+
+    def _mock_session(self, cli_output="ok\n", stream_chunks=None, parse_result=None):
+        """Create a mock SerialSession for CLI tests."""
+        mock_sess = MagicMock()
+        mock_sess.is_open = True
+        mock_sess.cli.return_value = sdev.SerialResult(
+            "cmd", cli_output, False, 0.1)
+        if stream_chunks is None:
+            stream_chunks = ["line1\n", "line2\n"]
+        mock_sess.stream.return_value = iter(stream_chunks)
+        if parse_result is None:
+            parse_result = sdev.ParseResult(
+                lines=["MemTotal: 1000"], matched=["MemTotal: 1000"],
+                raw="MemTotal: 1000\n")
+        mock_sess.parse.return_value = parse_result
+        mock_sess.doctor = MagicMock()
+        return mock_sess
+
+    def _run_main(self, args):
+        """Run main() with given argv, return captured stdout."""
+        mock_ser = MagicMock()
+        mock_ser.is_open = True
+        mock_ser.read.return_value = b""
+
+        with patch("sys.argv", ["sdev"] + args), \
+             patch("sdev.serial.Serial", return_value=mock_ser), \
+             patch("io.StringIO", return_value=io.StringIO()) as mock_io:
+            captured = io.StringIO()
+            with patch("sys.stdout", captured):
+                main()
+            return captured.getvalue()
+
+    def test_cli_normal_mode_full_flow(self):
+        """Normal mode: connect, run command, detect prompt, return output."""
+        mock_sess = self._mock_session(cli_output="hello\n")
+        mock_ser = MagicMock()
+
+        with patch("sys.argv", ["sdev", "-p", "echo hello",
+                                "-d", "/dev/ttyS0", "-b", "9600"]), \
+             patch("sdev.SerialSession") as mock_cls, \
+             patch("sdev.serial.Serial", return_value=mock_ser):
+            mock_cls.return_value.__enter__ = MagicMock(return_value=mock_sess)
+            mock_cls.return_value.__exit__ = MagicMock(return_value=False)
+
+            captured = io.StringIO()
+            with patch("sys.stdout", captured):
+                main()
+
+            self.assertEqual(captured.getvalue(), "hello\n")
+            mock_sess.cli.assert_called_once_with(
+                "echo hello", timeout=None, end_flag=None)
+
+    def test_cli_stream_with_grep_filter(self):
+        """Stream mode with --grep: filter applied, timeout passed."""
+        mock_sess = self._mock_session(
+            stream_chunks=["ERROR: disk\n", "INFO: ok\n", "ERROR: net\n"])
+        mock_ser = MagicMock()
+
+        with patch("sys.argv", ["sdev", "-p", "tail -f log",
+                                "--stream", "--grep", "ERROR",
+                                "-t", "15",
+                                "-d", "/dev/ttyS0", "-b", "9600"]), \
+             patch("sdev.SerialSession") as mock_cls, \
+             patch("sdev.serial.Serial", return_value=mock_ser):
+            mock_cls.return_value.__enter__ = MagicMock(return_value=mock_sess)
+            mock_cls.return_value.__exit__ = MagicMock(return_value=False)
+
+            captured = io.StringIO()
+            with patch("sys.stdout", captured):
+                main()
+
+            mock_sess.stream.assert_called_once()
+            call_kwargs = mock_sess.stream.call_args
+            self.assertEqual(call_kwargs[1]["timeout"], 15.0)
+            self.assertIsNotNone(call_kwargs[1]["filter_fn"])
+            # Verify filter actually filters
+            filter_fn = call_kwargs[1]["filter_fn"]
+            self.assertEqual(filter_fn("ERROR: bad\n"), "ERROR: bad\n")
+            self.assertEqual(filter_fn("INFO: ok\n"), "")
+
+    def test_cli_stream_with_line_mode(self):
+        """Stream mode with --line-mode: line_mode=True passed."""
+        mock_sess = self._mock_session()
+        mock_ser = MagicMock()
+
+        with patch("sys.argv", ["sdev", "-p", "dmesg",
+                                "--stream", "--line-mode",
+                                "-d", "/dev/ttyS0", "-b", "9600"]), \
+             patch("sdev.SerialSession") as mock_cls, \
+             patch("sdev.serial.Serial", return_value=mock_ser):
+            mock_cls.return_value.__enter__ = MagicMock(return_value=mock_sess)
+            mock_cls.return_value.__exit__ = MagicMock(return_value=False)
+
+            captured = io.StringIO()
+            with patch("sys.stdout", captured):
+                main()
+
+            mock_sess.stream.assert_called_once()
+            call_kwargs = mock_sess.stream.call_args
+            self.assertTrue(call_kwargs[1]["line_mode"])
+
+    def test_cli_with_end_flag(self):
+        """CLI --end-flag passed to both cli() and stream()."""
+        mock_sess = self._mock_session()
+        mock_ser = MagicMock()
+
+        with patch("sys.argv", ["sdev", "-p", "./bench",
+                                "--end-flag", "Frame rate:",
+                                "-d", "/dev/ttyS0", "-b", "9600"]), \
+             patch("sdev.SerialSession") as mock_cls, \
+             patch("sdev.serial.Serial", return_value=mock_ser):
+            mock_cls.return_value.__enter__ = MagicMock(return_value=mock_sess)
+            mock_cls.return_value.__exit__ = MagicMock(return_value=False)
+
+            captured = io.StringIO()
+            with patch("sys.stdout", captured):
+                main()
+
+            mock_sess.cli.assert_called_once_with(
+                "./bench", timeout=None, end_flag="Frame rate:")
+
+    def test_cli_with_doctor(self):
+        """CLI --doctor calls doctor() before running command."""
+        mock_sess = self._mock_session()
+        mock_ser = MagicMock()
+
+        with patch("sys.argv", ["sdev", "-p", "uptime",
+                                "--doctor",
+                                "-d", "/dev/ttyS0", "-b", "9600"]), \
+             patch("sdev.SerialSession") as mock_cls, \
+             patch("sdev.serial.Serial", return_value=mock_ser):
+            mock_cls.return_value.__enter__ = MagicMock(return_value=mock_sess)
+            mock_cls.return_value.__exit__ = MagicMock(return_value=False)
+
+            captured = io.StringIO()
+            with patch("sys.stdout", captured):
+                main()
+
+            mock_sess.doctor.assert_called_once()
+            mock_sess.cli.assert_called_once()
+            # doctor must be called before cli
+            call_order = [
+                mock_sess.doctor.call_count > 0,
+                mock_sess.cli.call_count > 0,
+            ]
+            self.assertTrue(all(call_order))
+
+    def test_cli_with_custom_prompts(self):
+        """CLI --prompt passes byte-encoded prompts to SerialSession."""
+        mock_sess = self._mock_session()
+        mock_ser = MagicMock()
+
+        with patch("sys.argv", ["sdev", "-p", "ls",
+                                "--prompt", "[root]# ",
+                                "--prompt", "admin> ",
+                                "-d", "/dev/ttyS0", "-b", "9600"]), \
+             patch("sdev.SerialSession") as mock_cls, \
+             patch("sdev.serial.Serial", return_value=mock_ser):
+            mock_cls.return_value.__enter__ = MagicMock(return_value=mock_sess)
+            mock_cls.return_value.__exit__ = MagicMock(return_value=False)
+
+            captured = io.StringIO()
+            with patch("sys.stdout", captured):
+                main()
+
+            # SerialSession should be called with byte-encoded prompts
+            mock_cls.assert_called_once()
+            call_kwargs = mock_cls.call_args
+            prompts = call_kwargs[1].get("prompts")
+            self.assertEqual(prompts, [b"[root]# ", b"admin> "])
+
+    def test_cli_timeout_exit_code(self):
+        """CLI returns exit code 2 when command times out."""
+        mock_sess = MagicMock()
+        mock_sess.cli.return_value = sdev.SerialResult(
+            "sleep 999", "", True, 5.0)
+        mock_ser = MagicMock()
+
+        with patch("sys.argv", ["sdev", "-p", "sleep 999",
+                                "-d", "/dev/ttyS0", "-b", "9600"]), \
+             patch("sdev.SerialSession") as mock_cls, \
+             patch("sdev.serial.Serial", return_value=mock_ser):
+            mock_cls.return_value.__enter__ = MagicMock(return_value=mock_sess)
+            mock_cls.return_value.__exit__ = MagicMock(return_value=False)
+
+            captured = io.StringIO()
+            with patch("sys.stdout", captured):
+                with self.assertRaises(SystemExit) as cm:
+                    main()
+                self.assertEqual(cm.exception.code, 2)
+
+    def test_cli_parse_no_matches_exit_code(self):
+        """CLI returns exit code 3 when --parse finds no matches."""
+        mock_sess = MagicMock()
+        mock_sess.parse.return_value = sdev.ParseResult(
+            lines=["foo", "bar"], matched=[], raw="foo\nbar\n")
+        mock_ser = MagicMock()
+
+        with patch("sys.argv", ["sdev", "-p", "cat file",
+                                "--parse", "NOTFOUND",
+                                "-d", "/dev/ttyS0", "-b", "9600"]), \
+             patch("sdev.SerialSession") as mock_cls, \
+             patch("sdev.serial.Serial", return_value=mock_ser):
+            mock_cls.return_value.__enter__ = MagicMock(return_value=mock_sess)
+            mock_cls.return_value.__exit__ = MagicMock(return_value=False)
+
+            captured = io.StringIO()
+            with patch("sys.stdout", captured):
+                with self.assertRaises(SystemExit) as cm:
+                    main()
+                self.assertEqual(cm.exception.code, 3)
+
+
+class TestCLISetDefault(unittest.TestCase):
+    """Integration tests for set-default subcommand."""
+
+    def test_set_default_writes_config(self):
+        """set-default should write JSON config file."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cfg_file = os.path.join(tmpdir, "defaults.json")
+            with patch.object(sdev, "CONFIG_FILE", __file__):
+                # Use a temp path for the actual write
+                import json
+                from pathlib import Path
+                tmp_path = Path(tmpdir) / "defaults.json"
+                with patch.object(sdev, "CONFIG_FILE", tmp_path), \
+                     patch.object(sdev, "CONFIG_DIR", tmp_path.parent), \
+                     patch("sys.argv", ["sdev", "set-default",
+                                        "/dev/ttyACM0", "57600"]):
+                    captured = io.StringIO()
+                    with patch("sys.stdout", captured):
+                        main()
+
+                    data = json.loads(tmp_path.read_text())
+                    self.assertEqual(data["device"], "/dev/ttyACM0")
+                    self.assertEqual(data["baud"], 57600)
+
+
+class TestCLILoadDefaults(unittest.TestCase):
+    """CLI should load saved defaults when -d/-b omitted."""
+
+    def test_load_defaults_applied(self):
+        """When no -d/-b given, loaded defaults should be used."""
+        mock_sess = MagicMock()
+        mock_sess.cli.return_value = sdev.SerialResult(
+            "echo ok", "ok\n", False, 0.1)
+        mock_ser = MagicMock()
+
+        defaults = {"device": "/dev/ttyACM0", "baud": 57600}
+
+        with patch("sdev.load_defaults", return_value=defaults), \
+             patch("sys.argv", ["sdev", "-p", "echo ok"]), \
+             patch("sdev.SerialSession") as mock_cls, \
+             patch("sdev.serial.Serial", return_value=mock_ser):
+            mock_cls.return_value.__enter__ = MagicMock(return_value=mock_sess)
+            mock_cls.return_value.__exit__ = MagicMock(return_value=False)
+
+            captured = io.StringIO()
+            with patch("sys.stdout", captured):
+                main()
+
+            # SerialSession should be called with loaded defaults
+            mock_cls.assert_called_once()
+            call_args = mock_cls.call_args
+            self.assertEqual(call_args[0][0], "/dev/ttyACM0")
+            self.assertEqual(call_args[0][1], 57600)
+
+    def test_cli_overrides_defaults(self):
+        """CLI flags should override loaded defaults."""
+        mock_sess = MagicMock()
+        mock_sess.cli.return_value = sdev.SerialResult(
+            "echo ok", "ok\n", False, 0.1)
+        mock_ser = MagicMock()
+
+        defaults = {"device": "/dev/ttyACM0", "baud": 57600}
+
+        with patch("sdev.load_defaults", return_value=defaults), \
+             patch("sys.argv", ["sdev", "-p", "echo ok",
+                                "-d", "/dev/ttyUSB1", "-b", "115200"]), \
+             patch("sdev.SerialSession") as mock_cls, \
+             patch("sdev.serial.Serial", return_value=mock_ser):
+            mock_cls.return_value.__enter__ = MagicMock(return_value=mock_sess)
+            mock_cls.return_value.__exit__ = MagicMock(return_value=False)
+
+            captured = io.StringIO()
+            with patch("sys.stdout", captured):
+                main()
+
+            mock_cls.assert_called_once()
+            call_args = mock_cls.call_args
+            self.assertEqual(call_args[0][0], "/dev/ttyUSB1")
+            self.assertEqual(call_args[0][1], 115200)
+
+
+class TestModuleLevelAPI(unittest.TestCase):
+    """Module-level convenience APIs should delegate correctly."""
+
+    def test_module_cli_delegates(self):
+        """sdev.cli() should call default session's cli()."""
+        mock_sess = MagicMock()
+        mock_sess.cli.return_value = sdev.SerialResult(
+            "echo x", "x\n", False, 0.01)
+
+        with patch.object(sdev, "_default_session", mock_sess):
+            result = sdev.cli("echo x", timeout=5)
+
+        mock_sess.cli.assert_called_once_with("echo x", 5)
+        self.assertEqual(result.output, "x\n")
+
+    def test_module_connect_delegates(self):
+        """sdev.connect() should call default session's connect()."""
+        mock_sess = MagicMock()
+        with patch.object(sdev, "_default_session", mock_sess):
+            sdev.connect("/dev/ttyS1", 9600)
+        mock_sess.connect.assert_called_once_with("/dev/ttyS1", 9600)
+
+    def test_module_disconnect_delegates(self):
+        """sdev.disconnect() should call default session's close()."""
+        mock_sess = MagicMock()
+        with patch.object(sdev, "_default_session", mock_sess):
+            sdev.disconnect()
+        mock_sess.close.assert_called_once()
+
+    def test_module_stream_delegates(self):
+        """sdev.stream() should yield from default session's stream()."""
+        mock_sess = MagicMock()
+        mock_sess.stream.return_value = iter(["a\n", "b\n"])
+
+        with patch.object(sdev, "_default_session", mock_sess):
+            chunks = list(sdev.stream("tail -f log"))
+
+        self.assertEqual(chunks, ["a\n", "b\n"])
+        mock_sess.stream.assert_called_once()
+
+    def test_module_parse_delegates(self):
+        """sdev.parse() should call default session's parse()."""
+        mock_sess = MagicMock()
+        mock_sess.parse.return_value = sdev.ParseResult(
+            lines=["a", "b"], matched=["a"], raw="a\nb\n")
+
+        with patch.object(sdev, "_default_session", mock_sess):
+            result = sdev.parse("cmd", pattern="a", timeout=10)
+
+        mock_sess.parse.assert_called_once_with("cmd", "a", 10)
+        self.assertEqual(result.matched, ["a"])
+
+    def test_module_interrupt_delegates(self):
+        """sdev.interrupt() should call default session's interrupt()."""
+        mock_sess = MagicMock()
+        mock_sess.interrupt.return_value = True
+
+        with patch.object(sdev, "_default_session", mock_sess):
+            result = sdev.interrupt(timeout=3)
+
+        mock_sess.interrupt.assert_called_once_with(3)
+        self.assertTrue(result)
+
+    def test_module_reconnect_delegates(self):
+        """sdev.reconnect() should call default session's reconnect()."""
+        mock_sess = MagicMock()
+        with patch.object(sdev, "_default_session", mock_sess):
+            sdev.reconnect()
+        mock_sess.reconnect.assert_called_once()
+
+    def test_ensure_connection_raises_when_not_open(self):
+        """sdev.ensure_connection() should raise when not connected."""
+        mock_sess = MagicMock()
+        mock_sess._ensure_open.side_effect = RuntimeError("Not connected")
+
+        with patch.object(sdev, "_default_session", mock_sess):
+            with self.assertRaises(RuntimeError):
+                sdev.ensure_connection()
+
+
+class TestSessionContextManager(unittest.TestCase):
+    """SerialSession context manager behavior."""
+
+    def test_enter_connects_if_not_open(self):
+        """__enter__ should call connect() when not connected."""
+        sess = sdev.SerialSession()
+        mock_ser = MagicMock()
+
+        with patch.object(sess, "connect", wraps=sess.connect) as mock_connect:
+            with patch.object(sdev.serial, "Serial", return_value=mock_ser):
+                with sess:
+                    pass
+
+        mock_connect.assert_called_once()
+
+    def test_enter_skips_connect_if_already_open(self):
+        """__enter__ should NOT call connect() when already open."""
+        mock_ser = MagicMock()
+        mock_ser.is_open = True
+
+        sess = sdev.SerialSession()
+        sess._connection = mock_ser
+
+        with patch.object(sess, "connect") as mock_connect:
+            with sess:
+                pass
+
+        mock_connect.assert_not_called()
+
+    def test_exit_closes_connection(self):
+        """__exit__ should call close()."""
+        mock_ser = MagicMock()
+        mock_ser.is_open = True
+
+        sess = sdev.SerialSession()
+        sess._connection = mock_ser
+
+        with sess:
+            pass
+
+        self.assertIsNone(sess._connection)
+
+
+class TestDefaultsPersistence(unittest.TestCase):
+    """save_default / load_defaults round-trip."""
+
+    def test_save_and_load_roundtrip(self):
+        """save_default then load_defaults should return saved values."""
+        import tempfile
+        from pathlib import Path
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp_path = Path(tmpdir) / "defaults.json"
+            with patch.object(sdev, "CONFIG_FILE", tmp_path), \
+                 patch.object(sdev, "CONFIG_DIR", tmp_path.parent):
+                sdev.save_default("/dev/ttyACM0", 57600)
+                defaults = sdev.load_defaults()
+                self.assertEqual(defaults["device"], "/dev/ttyACM0")
+                self.assertEqual(defaults["baud"], 57600)
+
+    def test_load_defaults_empty_when_no_file(self):
+        """load_defaults should return {} when config doesn't exist."""
+        import tempfile
+        from pathlib import Path
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp_path = Path(tmpdir) / "nonexistent.json"
+            with patch.object(sdev, "CONFIG_FILE", tmp_path):
+                defaults = sdev.load_defaults()
+                self.assertEqual(defaults, {})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_error_handling.py
+++ b/tests/test_error_handling.py
@@ -261,8 +261,9 @@ class TestCLILargeOutputNoMemoryLeak(unittest.TestCase):
 
         result = sess.cli("big_output", timeout=30)
         self.assertFalse(result.timed_out)
-        # Buffer should have been trimmed — result may not have all A's
-        # but it should not crash or hang
+        # Buffer should have been trimmed — output should not contain
+        # all 65636 bytes of A's
+        self.assertLess(len(result.output), sdev.MAX_BUFFER_SIZE)
 
 
 class TestParseWithNoPattern(unittest.TestCase):

--- a/tests/test_error_handling.py
+++ b/tests/test_error_handling.py
@@ -319,12 +319,27 @@ class TestPromptDetectionEdgeCases(unittest.TestCase):
 class TestModuleLevelRunWithEndFlag(unittest.TestCase):
     """sdev.run() should support end_flag parameter."""
 
-    def test_run_missing_end_flag(self):
-        """run() currently doesn't accept end_flag — verify signature."""
+    def test_run_has_end_flag(self):
+        """run() should accept end_flag parameter."""
         import inspect
         sig = inspect.signature(sdev.run)
         params = list(sig.parameters.keys())
-        self.assertNotIn("end_flag", params)
+        self.assertIn("end_flag", params)
+
+    def test_run_passes_end_flag(self):
+        """run() should pass end_flag to session.cli()."""
+        with patch.object(sdev, "SerialSession") as mock_cls:
+            mock_sess = MagicMock()
+            mock_sess.cli.return_value = sdev.SerialResult(
+                "bench", "Frame rate: 60\n", False, 1.0)
+            mock_cls.return_value = mock_sess
+
+            result = sdev.run("/dev/ttyUSB0", 115200, "bench",
+                              end_flag="Frame rate:")
+
+            mock_sess.cli.assert_called_once_with(
+                "bench", None, "Frame rate:")
+            self.assertFalse(result.timed_out)
 
 
 if __name__ == "__main__":

--- a/tests/test_error_handling.py
+++ b/tests/test_error_handling.py
@@ -1,0 +1,331 @@
+"""Adversarial tests for error handling, exception propagation, and edge cases.
+
+Tests paths that don't occur in normal operation but could be triggered
+by misconfiguration, unexpected serial behavior, or concurrent misuse.
+"""
+
+import unittest
+from unittest.mock import MagicMock, patch, PropertyMock
+
+import sdev
+
+
+class TestFilterFnExceptionPropagation(unittest.TestCase):
+    """Verify filter_fn exceptions propagate through stream() properly."""
+
+    def test_filter_fn_exception_propagates(self):
+        """If filter_fn raises, stream() should propagate the exception."""
+        mock_ser = MagicMock()
+        mock_ser.is_open = True
+        mock_ser.read.side_effect = [b"hello\n", b"# "]
+
+        def bad_filter(text):
+            raise ValueError("filter broke")
+
+        sess = sdev.SerialSession()
+        sess._connection = mock_ser
+
+        it = sess.stream("cmd", filter_fn=bad_filter)
+        with self.assertRaises(ValueError) as ctx:
+            list(it)
+        self.assertEqual(str(ctx.exception), "filter broke")
+
+    def test_filter_fn_exception_releases_lock(self):
+        """After filter_fn raises, the lock must be released."""
+        mock_ser = MagicMock()
+        mock_ser.is_open = True
+        mock_ser.read.side_effect = [b"hello\n", b"# "]
+
+        def bad_filter(text):
+            raise ValueError("filter broke")
+
+        sess = sdev.SerialSession()
+        sess._connection = mock_ser
+
+        it = sess.stream("cmd", filter_fn=bad_filter)
+        with self.assertRaises(ValueError):
+            list(it)
+
+        # Lock should be released — acquire should succeed
+        acquired = sess._lock.acquire(timeout=1)
+        self.assertTrue(acquired)
+        sess._lock.release()
+
+
+class TestSerialExceptionDuringCli(unittest.TestCase):
+    """Serial error during cli() should return a clean result, not raise."""
+
+    def test_serial_error_returns_result_with_error_message(self):
+        """cli() should catch SerialException and return error output."""
+        mock_ser = MagicMock()
+        mock_ser.is_open = True
+        mock_ser.read.side_effect = sdev.serial.SerialException("device lost")
+
+        sess = sdev.SerialSession()
+        sess._connection = mock_ser
+
+        result = sess.cli("cmd", timeout=5)
+        self.assertTrue(result.timed_out)
+        self.assertIn("serial error", result.output)
+        self.assertIn("device lost", result.output)
+
+
+class TestStreamSerialExceptionRecovery(unittest.TestCase):
+    """Serial error during stream() should stop iteration, not crash."""
+
+    def test_stream_stops_on_serial_error(self):
+        """stream() should catch SerialException and stop."""
+        mock_ser = MagicMock()
+        mock_ser.is_open = True
+        mock_ser.read.side_effect = [b"line1\n", sdev.serial.SerialException("disconnect")]
+
+        sess = sdev.SerialSession()
+        sess._connection = mock_ser
+
+        chunks = list(sess.stream("cmd", timeout=5))
+        # Should have gotten line1 before the error
+        self.assertIn("line1", "".join(chunks))
+
+    def test_stream_releases_lock_on_error(self):
+        """Lock must be released even when stream() hits an error."""
+        mock_ser = MagicMock()
+        mock_ser.is_open = True
+        mock_ser.read.side_effect = sdev.serial.SerialException("disconnect")
+
+        sess = sdev.SerialSession()
+        sess._connection = mock_ser
+
+        list(sess.stream("cmd", timeout=5))
+
+        acquired = sess._lock.acquire(timeout=1)
+        self.assertTrue(acquired)
+        sess._lock.release()
+
+
+class TestEnsureOpenRaisesWhenNotConnected(unittest.TestCase):
+    """_ensure_open() should raise with clear message when not connected."""
+
+    def test_ensure_open_raises_with_device_info(self):
+        """Error message should include device/baud for debugging."""
+        sess = sdev.SerialSession("/dev/ttyS99", 9600)
+        with self.assertRaises(RuntimeError) as ctx:
+            sess._ensure_open()
+        self.assertIn("/dev/ttyS99", str(ctx.exception))
+        self.assertIn("9600", str(ctx.exception))
+
+
+class TestConnectSerialException(unittest.TestCase):
+    """connect() should wrap SerialException in RuntimeError."""
+
+    def test_connect_wraps_exception(self):
+        """connect() should raise RuntimeError with device info."""
+        with patch("sdev.serial.Serial") as mock_cls:
+            mock_cls.side_effect = sdev.serial.SerialException(
+                "[Errno 2] No such file")
+            sess = sdev.SerialSession("/dev/ttyNOPE", 115200)
+            with self.assertRaises(RuntimeError) as ctx:
+                sess.connect()
+            self.assertIn("/dev/ttyNOPE", str(ctx.exception))
+            self.assertIsNone(sess._connection)
+
+
+class TestCloseIsSafeWhenAlreadyClosed(unittest.TestCase):
+    """close() should be safe to call multiple times."""
+
+    def test_close_when_not_connected(self):
+        """close() on an unconnected session should not raise."""
+        sess = sdev.SerialSession()
+        sess.close()  # should not raise
+        sess.close()  # twice either
+
+    def test_close_when_connection_already_closed(self):
+        """close() should handle already-closed serial port."""
+        mock_ser = MagicMock()
+        mock_ser.is_open = False
+        mock_ser.close.side_effect = sdev.serial.SerialException("already closed")
+
+        sess = sdev.SerialSession()
+        sess._connection = mock_ser
+        sess.close()  # should not raise
+        self.assertIsNone(sess._connection)
+
+
+class TestLockConcurrency(unittest.TestCase):
+    """Lock behavior under concurrent access."""
+
+    def test_two_sessions_have_independent_locks(self):
+        """Two SerialSession instances should have independent locks."""
+        s1 = sdev.SerialSession()
+        s2 = sdev.SerialSession()
+        self.assertIsNot(s1._lock, s2._lock)
+
+    def test_lock_acquire_timeout_returns_false_when_held(self):
+        """Lock should return False when held for longer than timeout."""
+        sess = sdev.SerialSession()
+        sess._lock.acquire()
+
+        # Second acquire should fail with short timeout
+        import threading
+        result = [None]
+
+        def try_lock():
+            result[0] = sess._lock.acquire(timeout=0.1)
+
+        t = threading.Thread(target=try_lock)
+        t.start()
+        t.join(timeout=2)
+        self.assertFalse(result[0])
+        sess._lock.release()
+
+
+class TestInterruptDoesNotAcquireLock(unittest.TestCase):
+    """interrupt() must not acquire the lock — it's the emergency escape."""
+
+    def test_interrupt_does_not_acquire_lock(self):
+        """interrupt() should work even when lock is held."""
+        mock_ser = MagicMock()
+        mock_ser.is_open = True
+        mock_ser.read.side_effect = [b"# "]
+
+        sess = sdev.SerialSession()
+        sess._connection = mock_ser
+
+        # Hold the lock
+        sess._lock.acquire()
+        try:
+            # interrupt should still work (doesn't acquire lock)
+            ok = sess.interrupt(timeout=0.1)
+            # It may or may not detect prompt depending on mock data
+            # The key is it didn't hang
+        finally:
+            sess._lock.release()
+
+
+class TestCliImplTimeoutInterruptCalled(unittest.TestCase):
+    """cli() should call interrupt() on timeout to clean up."""
+
+    def test_cli_calls_interrupt_on_timeout(self):
+        """cli() should attempt interrupt when timeout elapses."""
+        mock_ser = MagicMock()
+        mock_ser.is_open = True
+        mock_ser.read.return_value = b""
+
+        sess = sdev.SerialSession()
+        sess._connection = mock_ser
+
+        with patch.object(sess, "interrupt", return_value=False) as mock_int:
+            result = sess.cli("long_cmd", timeout=0.001)
+            self.assertTrue(result.timed_out)
+            mock_int.assert_called_once_with(timeout=0.5)
+
+
+class TestStreamEndFlagStopsOutput(unittest.TestCase):
+    """end_flag in stream() should stop iteration when marker appears."""
+
+    def test_stream_stops_at_end_flag(self):
+        """stream() should stop yielding after end_flag appears."""
+        mock_ser = MagicMock()
+        mock_ser.is_open = True
+        mock_ser.read.side_effect = [
+            b"running...\n",
+            b"Frame rate: 60fps\n",
+            b"still running...\n",  # should not be reached
+            b"# ",
+        ]
+
+        sess = sdev.SerialSession()
+        sess._connection = mock_ser
+
+        chunks = list(sess.stream("./bench", end_flag="Frame rate:"))
+        combined = "".join(chunks)
+        self.assertIn("Frame rate: 60fps", combined)
+        self.assertNotIn("still running", combined)
+
+
+class TestCLILargeOutputNoMemoryLeak(unittest.TestCase):
+    """cli() with large output should not grow buffer unboundedly."""
+
+    def test_cli_trims_buffer(self):
+        """cli() should trim buffer if it exceeds MAX_BUFFER_SIZE."""
+        mock_ser = MagicMock()
+        mock_ser.is_open = True
+
+        # Send a response larger than MAX_BUFFER_SIZE (64KB)
+        big = b"A" * (65536 + 100)
+        chunks = [big[i:i+4096] for i in range(0, len(big), 4096)]
+        chunks.append(b"# ")  # prompt at end
+        mock_ser.read.side_effect = chunks
+
+        sess = sdev.SerialSession()
+        sess._connection = mock_ser
+
+        result = sess.cli("big_output", timeout=30)
+        self.assertFalse(result.timed_out)
+        # Buffer should have been trimmed — result may not have all A's
+        # but it should not crash or hang
+
+
+class TestParseWithNoPattern(unittest.TestCase):
+    """parse() without pattern should return all lines."""
+
+    def test_parse_without_pattern(self):
+        """parse() should return all non-empty lines when no pattern."""
+        mock_sess = MagicMock()
+        mock_sess.cli.return_value = sdev.SerialResult(
+            "cmd", "line1\nline2\n\nline3\n", False, 0.1)
+
+        sess = sdev.SerialSession()
+        with patch.object(sess, "cli", mock_sess.cli):
+            result = sess.parse("cmd")
+
+        self.assertEqual(result.lines, ["line1", "line2", "line3"])
+        self.assertEqual(result.matched, [])
+
+
+class TestPromptDetectionEdgeCases(unittest.TestCase):
+    """Prompt detection should handle tricky buffer states."""
+
+    def test_prompt_in_middle_of_buffer(self):
+        """Prompt detection should work even when prompt isn't at very end."""
+        sess = sdev.SerialSession()
+        # Prompt not at end — should not match
+        self.assertFalse(sess._check_prompt(b"output # \nmore"))
+        # Prompt at end after newline strip — should match
+        self.assertTrue(sess._check_prompt(b"output # \n"))
+
+    def test_empty_buffer_no_prompt(self):
+        """_check_prompt on empty buffer should return False."""
+        sess = sdev.SerialSession()
+        self.assertFalse(sess._check_prompt(b""))
+
+    def test_ansi_stripped_from_output(self):
+        """ANSI sequences should be stripped from cli() output."""
+        mock_ser = MagicMock()
+        mock_ser.is_open = True
+        # Response with ANSI color code, followed by plain prompt
+        response = b"\x1b[01;32mhello\x1b[0m\r\n# "
+        mock_ser.read.side_effect = [response]
+
+        sess = sdev.SerialSession()
+        sess._connection = mock_ser
+
+        result = sess.cli("cmd", timeout=1)
+        self.assertFalse(result.timed_out)
+        # The ANSI should be stripped from output
+        self.assertNotIn("\x1b[", result.output)
+        self.assertIn("hello", result.output)
+
+
+class TestModuleLevelRunWithEndFlag(unittest.TestCase):
+    """sdev.run() should support end_flag parameter."""
+
+    def test_run_missing_end_flag(self):
+        """run() currently doesn't accept end_flag — verify signature."""
+        import inspect
+        sig = inspect.signature(sdev.run)
+        params = list(sig.parameters.keys())
+        self.assertNotIn("end_flag", params)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_probe.py
+++ b/tests/test_probe.py
@@ -1,0 +1,154 @@
+"""Tests for probe() — board detection (issue #45)."""
+
+import os
+import sys
+import unittest
+from unittest.mock import MagicMock, patch
+
+import sdev
+
+
+class TestProbeDevicePatterns(unittest.TestCase):
+    """probe() should return platform-appropriate device patterns."""
+
+    def test_linux_usb_patterns(self):
+        """On Linux, should include /dev/ttyUSB* and /dev/ttyACM*."""
+        with patch.object(sdev, "_is_linux", return_value=True), \
+             patch.object(sdev, "_is_macos", return_value=False), \
+             patch.object(sdev, "_is_windows", return_value=False):
+            patterns = sdev._probe_device_patterns()
+        self.assertTrue(any("ttyUSB" in p for p in patterns))
+        self.assertTrue(any("ttyACM" in p for p in patterns))
+
+    def test_macos_usb_patterns(self):
+        """On macOS, should include /dev/tty.usb* and /dev/cu.usb*."""
+        with patch.object(sdev, "_is_linux", return_value=False), \
+             patch.object(sdev, "_is_macos", return_value=True), \
+             patch.object(sdev, "_is_windows", return_value=False):
+            patterns = sdev._probe_device_patterns()
+        self.assertTrue(any("tty.usb" in p for p in patterns))
+        self.assertTrue(any("cu.usb" in p for p in patterns))
+
+    def test_windows_com_patterns(self):
+        """On Windows, should include COM*."""
+        with patch.object(sdev, "_is_linux", return_value=False), \
+             patch.object(sdev, "_is_macos", return_value=False), \
+             patch.object(sdev, "_is_windows", return_value=True):
+            patterns = sdev._probe_device_patterns()
+        self.assertTrue(any("COM" in p for p in patterns))
+
+
+class TestProbeEnumerateDevices(unittest.TestCase):
+    """probe() should enumerate actual devices."""
+
+    def test_returns_devices_found_on_linux(self):
+        """probe() should return list of existing /dev/ttyUSB* devices."""
+
+        def fake_is_linux(): return True
+        def fake_is_macos(): return False
+        def fake_is_windows(): return False
+
+        with patch.object(sdev, "_is_linux", fake_is_linux), \
+             patch.object(sdev, "_is_macos", fake_is_macos), \
+             patch.object(sdev, "_is_windows", fake_is_windows), \
+             patch("sdev.glob.glob", side_effect=lambda p: [f"{p[:-1]}0", f"{p[:-1]}1"]):
+            devices = sdev._enumerate_devices()
+            # Should contain USB devices from all patterns
+            self.assertTrue(len(devices) > 0)
+            self.assertEqual(set(devices), set(devices))  # no crash
+
+    def test_returns_empty_when_no_devices(self):
+        """probe() should return empty list when no devices exist."""
+
+        def fake_is_linux(): return True
+        def fake_is_macos(): return False
+        def fake_is_windows(): return False
+
+        with patch.object(sdev, "_is_linux", fake_is_linux), \
+             patch.object(sdev, "_is_macos", fake_is_macos), \
+             patch.object(sdev, "_is_windows", fake_is_windows), \
+             patch("sdev.glob.glob", return_value=[]):
+            devices = sdev._enumerate_devices()
+            self.assertEqual(devices, [])
+
+
+class TestProbeBoardInfo(unittest.TestCase):
+    """probe() should extract board information from a live device."""
+
+    def test_board_info_from_mock_session(self):
+        """probe() should use cli() to read /etc/os-release, uname, etc."""
+        mock_sess = MagicMock()
+        mock_sess.is_open = True
+        mock_sess._connection = MagicMock()
+        mock_sess._connection.is_open = True
+
+        def fake_cli(cmd, **kw):
+            responses = {
+                "cat /etc/os-release": 'NAME="Ubuntu"\nVERSION="22.04"\n',
+                "uname -a": "Linux xc01 5.10.0 armv7l GNU/Linux\n",
+            }
+            output = responses.get(cmd, "")
+            return sdev.SerialResult(cmd, output, False, 0.1)
+
+        mock_sess.cli = fake_cli
+
+        info = sdev._probe_board_info(mock_sess)
+        self.assertEqual(info["os_name"], "Ubuntu")
+        self.assertIn("xc01", info["hostname"])
+        self.assertIn("armv7l", info["arch"])
+
+    def test_board_info_handles_timeout(self):
+        """probe() should handle timed-out commands gracefully."""
+        mock_sess = MagicMock()
+        mock_sess.is_open = True
+        mock_sess._connection = MagicMock()
+        mock_sess._connection.is_open = True
+
+        def fake_cli(cmd, **kw):
+            return sdev.SerialResult(cmd, "", True, 5.0)
+
+        mock_sess.cli = fake_cli
+
+        info = sdev._probe_board_info(mock_sess)
+        # Should return empty/unknown values, not crash
+        self.assertEqual(info.get("os_name"), "unknown")
+
+
+class TestProbeFunction(unittest.TestCase):
+    """Top-level probe() API."""
+
+    def test_probe_returns_list(self):
+        """probe() should return a list of device info dicts."""
+        import glob as _glob
+
+        with patch.object(_glob, "glob", return_value=[]), \
+             patch.object(sdev, "_is_linux", return_value=True), \
+             patch.object(sdev, "_is_macos", return_value=False), \
+             patch.object(sdev, "_is_windows", return_value=False):
+            results = sdev.probe()
+            self.assertIsInstance(results, list)
+            # Empty since no devices found
+            self.assertEqual(results, [])
+
+
+class TestPlatformDetection(unittest.TestCase):
+    """Platform detection helpers."""
+
+    def test_linux_detection(self):
+        """_is_linux() should return True on Linux."""
+        with patch.object(sys, "platform", "linux"):
+            self.assertTrue(sdev._is_linux())
+
+    def test_macos_detection(self):
+        """_is_macos() should return True on macOS."""
+        with patch.object(sys, "platform", "darwin"):
+            self.assertTrue(sdev._is_macos())
+
+    def test_windows_detection(self):
+        """_is_windows() should return True on Windows."""
+        with patch.object(sys, "platform", "win32"):
+            self.assertTrue(sdev._is_windows())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- **fix**: stream() buffer trim — capture `old_consumed` before reset, hoist trim to immediately after `ser.read()` to prevent unbounded memory growth
- **fix**: add `end_flag` parameter to module-level `cli()` and `run()`, add `line_mode`/`end_flag` to module-level `stream()`
- **feat**: `probe()` — automatic serial board detection with cross-platform device enumeration (Linux/macOS/Windows) and board info extraction
- **feat**: `--probe` / `--probe-baud` CLI flags
- **docs**: update README with all current CLI flags and Python API examples
- **tests**: 212 tests total — added 24 integration tests, 20 error handling tests, 11 probe tests, 8 CLI probe/interrupt tests

## Test plan

- [x] `pytest` passes: 212 tests, no failures
- [x] CLI help output verified
- [x] All open test issues triaged and closed (#44, #45)

🤖 Generated with [Claude Code](https://claude.com/claude-code)