### PR TITLE
test: add missing default timeout test for wait_for_silence()

### DIFF
--- a/tests/test_doctor_wait_silence.py
+++ b/tests/test_doctor_wait_silence.py
@@ -31,6 +31,12 @@ class TestModuleLevelWaitForSilence(unittest.TestCase):
             sdev.wait_for_silence(timeout=3.0)
             mock_sess.wait_for_silence.assert_called_once_with(3.0)
 
+    def test_wait_for_silence_default_timeout(self):
+        """sdev.wait_for_silence() should use default timeout of 1.5 if not specified."""
+        with patch.object(sdev, "_default_session") as mock_sess:
+            sdev.wait_for_silence()
+            mock_sess.wait_for_silence.assert_called_once_with(1.5)
+
 
 class TestDoctorOnlyCLI(unittest.TestCase):
     """CLI --doctor-only flag should run doctor and exit."""


### PR DESCRIPTION
## Summary
- Add `test_wait_for_silence_default_timeout` to `test_doctor_wait_silence.py`
- Verifies that calling `sdev.wait_for_silence()` without arguments passes the default timeout of `1.5` to the session method
- Mirrors the existing `test_doctor_default_timeout` test (issue #61)

## Test plan
- [x] `python -m pytest tests/test_doctor_wait_silence.py -v` passes (226/226 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)